### PR TITLE
Async http addition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ import os
 
 from setuptools import setup
 
+websocket_packages = ["websocket-client"]
+async_packages = ["crochet", "twisted"]
+
 setup(
     name="swaggerpy",
     version="0.2.0",
@@ -31,7 +34,8 @@ setup(
         "Programming Language :: Python",
     ],
     tests_require=["nose", "tissue", "coverage", "httpretty"],
-    install_requires=["requests", "websocket-client", "python-dateutil"],
+    install_requires=(["requests", "python-dateutil"] + websocket_packages +
+        async_packages),
     entry_points="""
     [console_scripts]
     swagger-codegen = swaggerpy.codegen:main

--- a/swagger_test/exception_test.py
+++ b/swagger_test/exception_test.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2014, Yelp, Inc.
+#
+
+import unittest
+from mock import Mock
+
+from swaggerpy.exception import HTTPError
+
+
+class HTTPErrorTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_request_response_population(self):
+        # Give preference to request in parameter
+        resp = Mock(**{'request': Mock()})
+        req = Mock()
+        error = HTTPError(request=req, response=resp)
+        self.assertEqual(resp, error.response)
+        self.assertEqual(req, error.request)

--- a/swaggerpy/async_http_client.py
+++ b/swaggerpy/async_http_client.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2014, Yelp, Inc.
+#
+
+"""Asynchronous HTTP client abstractions.
+"""
+
+from cStringIO import StringIO
+import json
+import logging
+import urllib
+
+import crochet
+
+import twisted.internet.error
+import twisted.web.client
+from swaggerpy import http_client
+from swaggerpy.exception import HTTPError
+from twisted.internet import reactor
+from twisted.internet.defer import Deferred
+from twisted.internet.protocol import Protocol
+from twisted.web.client import Agent
+from twisted.web.client import FileBodyProducer
+from twisted.web.http_headers import Headers
+
+log = logging.getLogger(__name__)
+
+
+class AsynchronousHttpClient(http_client.HttpClient):
+    """Asynchronous HTTP client implementation.
+    """
+
+    def setup(self, request_params):
+        """Sets up the request params as per Twisted Agent needs.
+        Sets up crochet and triggers the API request in background
+
+        :param request_params: request parameters for API call
+        :type request_params: dict
+        """
+        self.request_params = {
+            'method': str(request_params['method']),
+            'bodyProducer': stringify_body(request_params),
+            'headers': listify_headers(request_params['headers']),
+            'uri': str(request_params['url'] + '?' + urllib.urlencode(
+                request_params['params']))
+        }
+
+        crochet.setup()
+        self.eventual = self.fetch_deferred()
+
+    def wait(self, timeout):
+        """Requests based implemention with timeout
+
+        :param timeout: time in seconds to wait for response
+        :return: Requests response
+        :rtype:  requests.Response
+        """
+        log.info(u"%s %s", self.request_params.get('method'),
+                 self.request_params.get('uri'))
+        # finished_resp is returned here
+        # TODO: catch known exceptions and raise common exceptions
+        return self.eventual.wait(timeout)
+
+    @crochet.run_in_reactor
+    def fetch_deferred(self):
+        """The main core to start the reacter and run the API
+        in the background. Also the callbacks are registered here
+        """
+        finished_resp = Deferred()
+        agent = Agent(reactor)
+        deferred = agent.request(**self.request_params)
+
+        def response_callback(response):
+            """Callback for response received from server, even 4XX, 5XX possible
+            response param stores the headers and status code.
+            It needs a callback method to be registered to store the response
+            body which is provided using deliverBody
+            """
+            response.deliverBody(_HTTPBodyFetcher(self.request_params,
+                                                  response, finished_resp))
+        deferred.addCallback(response_callback)
+
+        def response_errback(reason):
+            """Error callback method like server not reachable or conn. refused
+
+            :param reason: The reason why request failed
+            :type reason: str
+            """
+            finished_resp.errback(reason)
+        deferred.addErrback(response_errback)
+
+        return finished_resp
+
+
+class AsyncResponse():
+    """AsyncResponse inherits from requests.Response
+    to inherit methods like json(), raise_for_status()
+
+    Remove the property text and content and make them as overridable attrs
+    """
+    def __init__(self, req, resp, data):
+        self.request = req
+        self.status_code = resp.code
+        self.headers = dict(resp.headers.getAllRawHeaders())
+        self.text = data
+
+    def raise_for_status(self):
+        """Raises stored `HTTPError`, if one occured.
+        """
+
+        http_error_msg = ''
+
+        if 400 <= self.status_code < 500:
+            http_error_msg = '%s Client Error' % self.status_code
+
+        elif 500 <= self.status_code < 600:
+            http_error_msg = '%s Server Error' % self.status_code
+
+        if http_error_msg:
+            raise HTTPError(http_error_msg, response=self)
+
+    def json(self, **kwargs):
+        return json.loads(self.text, **kwargs)
+
+
+class _HTTPBodyFetcher(Protocol):
+    """Class to receive callbacks from Twisted whenever
+    response is available.
+
+    Eventually AsyncResponse() is created on receiving complete response
+    """
+    def __init__(self, request, response, finished):
+        self.buffer = StringIO()
+        self.request = request
+        self.response = response
+        self.finished = finished
+
+    def dataReceived(self, data):
+        self.buffer.write(data)
+
+    def connectionLost(self, reason):
+        # Accepting PotentialDataLoss for servers with HTTP1.0
+        # and not sending Content-Length in the header
+        if reason.check(twisted.web.client.ResponseDone) or \
+                reason.check(twisted.web.http.PotentialDataLoss):
+            self.finished.callback(AsyncResponse(
+                self.request, self.response, self.buffer.getvalue()))
+        else:
+            self.finished.errback(reason)
+
+
+def stringify_body(request_params):
+    """Wraps the data using twisted FileBodyProducer
+    """
+    http_client.stringify_body(request_params)
+    data = request_params['data']
+    return FileBodyProducer(StringIO(data)) if data else None
+
+
+def listify_headers(headers):
+    """Twisted agent requires header values as lists
+    """
+    headers = headers or {}
+    for key, val in headers.iteritems():
+        if not isinstance(val, list):
+            headers[key] = [val]
+    return Headers(headers)

--- a/swaggerpy/exception.py
+++ b/swaggerpy/exception.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2014, Yelp, Inc.
+#
+
+
+class HTTPError(IOError):
+    """Initialize HTTPError with 'response' and 'request' object
+    """
+    def __init__(self, *args, **kwargs):
+        response = kwargs.pop('response', None)
+        self.response = response
+        # populate request either from args or from response
+        self.request = kwargs.pop('request', None)
+        if(response is not None and not self.request and
+                hasattr(response, 'request')):
+            self.request = self.response.request
+        super(HTTPError, self).__init__(*args, **kwargs)

--- a/swaggerpy_test/async_http_client_test.py
+++ b/swaggerpy_test/async_http_client_test.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+
+#
+# Copyright (c) 2014, Yelp, Inc.
+#
+
+"""Unit tests for async http client related methods
+Not Tested:
+1) Callbacks triggered by twisted and crochet
+2) Timeouts by crochet's wait()
+"""
+
+import unittest
+from collections import namedtuple
+from mock import patch, Mock
+
+import swaggerpy.async_http_client
+import swaggerpy.exception
+import swaggerpy.http_client
+
+
+class AsyncHttpClientTest(unittest.TestCase):
+
+    def test_stringify_body_converts_dict_to_str(self):
+        request_params = {
+            'headers': {'content-type': 'application/json'},
+            'data': {'foo': 'bar', 'bar': 42}}
+        swaggerpy.http_client.stringify_body(request_params)
+        self.assertEqual('{"foo": "bar", "bar": 42}', request_params['data'])
+
+    def test_stringify_body_ignores_data_if_header_content_type_not_json(self):
+        request_params = {'headers': {}, 'data': 'foo'}
+        swaggerpy.http_client.stringify_body(request_params)
+        self.assertEqual('foo', request_params['data'])
+
+    def test_stringify_body_ignores_data_if_header_not_present(self):
+        request_params = {'data': 'foo'}
+        swaggerpy.http_client.stringify_body(request_params)
+        self.assertEqual('foo', request_params['data'])
+
+    def test_stringify_body_ignores_data_if_already_str(self):
+        request_params = {
+            'headers': {'content-type': 'application/json'},
+            'data': 'foo'}
+        swaggerpy.http_client.stringify_body(request_params)
+        self.assertEqual('foo', request_params['data'])
+
+    def test_stringify_async_body_returns_file_producer(self):
+        def_str = 'swaggerpy.http_client.stringify_body'
+        with patch(def_str) as mock_stringify:
+            with patch('swaggerpy.async_http_client.StringIO',
+                       return_value='foo') as mock_stringIO:
+                with patch('swaggerpy.async_http_client.FileBodyProducer',
+                           return_value='mock_fbp') as mock_fbp:
+                    resp = swaggerpy.async_http_client.stringify_body(
+                        {'data': 42})
+
+                    self.assertEqual('mock_fbp', resp)
+
+                    mock_stringify.assert_called_once_with({'data': 42})
+                    mock_stringIO.assert_called_once_with(42)
+                    mock_fbp.assert_called_once_with('foo')
+
+    def test_listify_headers(self):
+        headers = {'a': 'foo', 'b': ['bar', 42]}
+        resp = swaggerpy.async_http_client.listify_headers(headers)
+        self.assertEqual([('A', ['foo']), ('B', ['bar', 42])],
+                         list(resp.getAllRawHeaders()))
+
+    def test_success_AsyncHTTP_response(self):
+        Response = namedtuple("MyResponse",
+                              "version code phrase headers length deliverBody")
+        with patch.object(swaggerpy.async_http_client.AsynchronousHttpClient,
+                          'fetch_deferred') as mock_Async:
+            req = {
+                'method': 'GET',
+                'url': 'foo',
+                'data': None,
+                'headers': None,
+                'params': ''}
+            mock_Async.return_value.wait.return_value = Response(
+                1, 2, 3, 4, 5, 6)
+            async_client = swaggerpy.async_http_client.AsynchronousHttpClient()
+            async_client.setup(req)
+            resp = async_client.wait(5)
+            self.assertEqual(2, resp.code)
+
+
+class HTTPBodyFetcherTest(unittest.TestCase):
+
+    def setUp(self):
+        self.http_body_fetcher = swaggerpy.async_http_client._HTTPBodyFetcher(
+            'req', 'resp', Mock())
+
+    def test_HTTP_body_fetcher_data_received(self):
+        self.http_body_fetcher.dataReceived("helloWorld")
+        self.assertEqual("helloWorld",
+                         self.http_body_fetcher.buffer.getvalue())
+
+    def test_success_HTTP_body_fetcher_connection_lost(self):
+        response_str = 'swaggerpy.async_http_client.AsyncResponse'
+        with patch(response_str) as mock_resp:
+            self.http_body_fetcher.finished.callback.return_value = None
+            reason = Mock(**{'check.return_value': True})
+            self.http_body_fetcher.connectionLost(reason)
+            mock_resp.assert_called_once_with('req', 'resp', '')
+
+    def test_error_HTTP_body_fetcher_connection_lost(self):
+        errback = Mock()
+        self.http_body_fetcher.finished.errback = errback
+        reason = Mock(**{'check.return_value': False})
+        self.http_body_fetcher.connectionLost(reason)
+        errback.assert_called_once_with(reason)
+
+
+class AsyncResponseTest(unittest.TestCase):
+
+    def test_build_async_response(self):
+        headers_orig = {'a': 'foo', 'b': ['bar', 42]}
+        headers = swaggerpy.async_http_client.listify_headers(headers_orig)
+        resp = Mock(**{'code': 200, 'headers': headers})
+        req = Mock()
+        async_resp = swaggerpy.async_http_client.AsyncResponse(
+            req, resp, '{"valid":"json"}')
+        self.assertEqual(200, async_resp.status_code)
+        self.assertEqual(req, async_resp.request)
+        self.assertEqual({'A': ['foo'], 'B': ['bar', 42]}, async_resp.headers)
+        self.assertEqual({"valid": "json"}, async_resp.json())
+
+    def test_raise_for_status_client_error(self):
+        headers = swaggerpy.async_http_client.listify_headers({})
+        resp = Mock(**{'code': 400, 'headers': headers})
+        async = swaggerpy.async_http_client.AsyncResponse(None, resp, None)
+        try:
+            async.raise_for_status()
+        except swaggerpy.exception.HTTPError as e:
+            self.assertEqual('400 Client Error', str(e))
+
+    def test_raise_for_status_server_error(self):
+        headers = swaggerpy.async_http_client.listify_headers({})
+        resp = Mock(**{'code': 500, 'headers': headers})
+        async = swaggerpy.async_http_client.AsyncResponse(None, resp, None)
+        try:
+            async.raise_for_status()
+        except swaggerpy.exception.HTTPError as e:
+            self.assertEqual('500 Server Error', str(e))

--- a/swaggerpy_test/resource_api_test.py
+++ b/swaggerpy_test/resource_api_test.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+#
+# Copyright (c) 2014, Yelp, Inc.
+#
+
 """Swagger client tests to validate 'resource api's
 
 A sample 'resource api' is listed in the "apis" list below.

--- a/swaggerpy_test/resource_listing_test.py
+++ b/swaggerpy_test/resource_listing_test.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+#
+# Copyright (c) 2014, Yelp, Inc.
+#
+
 """Swagger client tests to validate 'resource_listing'.
 
 Sample 'resource_listing' this test intends to check is like:

--- a/swaggerpy_test/resource_model_test.py
+++ b/swaggerpy_test/resource_model_test.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+#
+# Copyright (c) 2014, Yelp, Inc.
+#
+
 """Swagger client tests to validate resource 'model's
 
 A sample 'model' is listed below in models list.

--- a/swaggerpy_test/resource_operation_test.py
+++ b/swaggerpy_test/resource_operation_test.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+#
+# Copyright (c) 2014, Yelp, Inc.
+#
+
 """Swagger client tests to validate resource api 'operation'
 
 A sample 'peration' is listed below in 'operations' list.

--- a/swaggerpy_test/resource_response_test.py
+++ b/swaggerpy_test/resource_response_test.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+#
+# Copyright (c) 2014, Yelp, Inc.
+#
+
 """Swagger client tests to validate resource api response
 
 The response is validated against Swagger spec specifications

--- a/swaggerpy_test/resource_test.py
+++ b/swaggerpy_test/resource_test.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+#
+# Copyright (c) 2014, Yelp, Inc.
+#
+
 """Swagger client tests to validate 'resource' declarations
 
 A sample 'resource' is listed below.


### PR DESCRIPTION
- Addition of AsynchronousHTTPClient and AsyncResponse class

```
running nosetests
running egg_info
writing requirements to swaggerpy.egg-info/requires.txt
writing swaggerpy.egg-info/PKG-INFO
writing top-level names to swaggerpy.egg-info/top_level.txt
writing dependency_links to swaggerpy.egg-info/dependency_links.txt
writing entry points to swaggerpy.egg-info/entry_points.txt
writing requirements to swaggerpy.egg-info/requires.txt
writing swaggerpy.egg-info/PKG-INFO
writing top-level names to swaggerpy.egg-info/top_level.txt
writing dependency_links to swaggerpy.egg-info/dependency_links.txt
writing entry points to swaggerpy.egg-info/entry_points.txt
reading manifest file 'swaggerpy.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'swaggerpy.egg-info/SOURCES.txt'
/nail/home/prateek/pg/mypy/lib/python2.6/site-packages/twisted/internet/endpoints.py:30: DeprecationWarning: twisted.internet.interfaces.IStreamClientEndpointStringParser was deprecated in Twisted 14.0.0: This interface has been superseded by IStreamClientEndpointStringParserWithReactor.
  from twisted.internet.interfaces import (
/nail/home/prateek/pg/mypy/lib/python2.6/site-packages/twisted/internet/_sslverify.py:184: UserWarning: Your version of pyOpenSSL, 0.10, is out of date.  Please upgrade to at least 0.12 and install service_identity from <https://pypi.python.org/pypi/service_identity>. Without the service_identity module and a recent enough pyOpenSSL tosupport it, Twisted can perform only rudimentary TLS client hostnameverification.  Many valid certificate/hostname mappings may be rejected.
  verifyHostname, VerificationError = _selectVerifyImplementation()
................................................................................
----------------------------------------------------------------------
Ran 80 tests in 0.537s

OK
```
