### PR TITLE
Change Future API to expose result(), cancel() and cancelled()

### DIFF
--- a/swaggerpy/async_http_client.py
+++ b/swaggerpy/async_http_client.py
@@ -50,6 +50,11 @@ class AsynchronousHttpClient(http_client.HttpClient):
         crochet.setup()
         self.eventual = self.fetch_deferred()
 
+    def cancel(self):
+        """Try to cancel the API call using crochet's cancel() API
+        """
+        self.eventual.cancel()
+
     def wait(self, timeout):
         """Requests based implemention with timeout
 

--- a/swaggerpy/exception.py
+++ b/swaggerpy/exception.py
@@ -17,3 +17,9 @@ class HTTPError(IOError):
                 hasattr(response, 'request')):
             self.request = self.response.request
         super(HTTPError, self).__init__(*args, **kwargs)
+
+
+class CancelledError():
+    """Error raised when result() is called from HTTPFuture
+    and call was actually cancelled
+    """

--- a/swaggerpy/http_client.py
+++ b/swaggerpy/http_client.py
@@ -90,11 +90,17 @@ class HttpClient(object):
             u"%s: Method not implemented", self.__class__.__name__)
 
     def wait(self, timeout):
-        """Similar to 'request', Calls the API with request_params until timeout.
+        """Calls the API with request_params and waits till timeout.
 
         :param timeout: time in seconds to wait for response.
         :type timeout: float
         :return: Implementation specific response
+        """
+        raise NotImplementedError(
+            u"%s: Method not implemented", self.__class__.__name__)
+
+    def cancel(self):
+        """Cancels the API call
         """
         raise NotImplementedError(
             u"%s: Method not implemented", self.__class__.__name__)
@@ -208,6 +214,10 @@ class SynchronousHttpClient(HttpClient):
         self.apply_authentication(req)
         return self.session.send(self.session.prepare_request(req),
                                  timeout=timeout)
+
+    def cancel(self):
+        """Nothing to be done for Synchronous client
+        """
 
     def request(self, method, url, params=None, data=None, headers=None):
         """Requests based implementation.

--- a/swaggerpy/response.py
+++ b/swaggerpy/response.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import dateutil.parser
 
 import swagger_type
+from swaggerpy.exception import CancelledError
 
 
 DEFAULT_TIMEOUT_S = 5.0
@@ -19,11 +20,36 @@ DEFAULT_TIMEOUT_S = 5.0
 class HTTPFuture(object):
     """A future which inputs HTTP params"""
     def __init__(self, http_client, request_params, postHTTP_callback):
+        """Kicks API call for Asynchronous client
+
+        :param http_client: instance with public methods: setup(), wait()
+        :param request_params: dict containing API request parameters
+        :param postHTTP_callback: function to callback on finish
+        """
         self._http_client = http_client
         self._postHTTP_callback = postHTTP_callback
         self._http_client.setup(request_params)
+        self._cancelled = False
 
-    def __call__(self, timeout=DEFAULT_TIMEOUT_S):
+    def cancelled(self):
+        """Checks if API is cancelled
+        Once cancelled, it can't be resumed
+        """
+        return self._cancelled
+
+    def cancel(self):
+        """Try to cancel the API (meaningful for Asynchronous client)
+        """
+        self._cancelled = True
+        self._http_client.cancel()
+
+    def result(self, timeout=DEFAULT_TIMEOUT_S):
+        """Blocking call to wait for API response
+        If API was cancelled earlier, CancelledError is raised
+        If everything goes fine, callback registered is triggered with response
+        """
+        if self.cancelled():
+            raise CancelledError()
         response = self._http_client.wait(timeout)
         response.raise_for_status()
         return self._postHTTP_callback(response)

--- a/swaggerpy_test/client_http_test.py
+++ b/swaggerpy_test/client_http_test.py
@@ -25,7 +25,7 @@ class ClientTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.POST, "http://localhost/test_http?",
             body='[]', content_type='text/json')
-        resp = self.client.simple1.createAsterikInfoHttp(body=body)()
+        resp = self.client.simple1.createAsterikInfoHttp(body=body).result()
         self.assertEqual('application/json',
                          httpretty.last_request().headers['content-type'])
         self.assertEqual('{"id": "test_id"}',

--- a/swaggerpy_test/client_test.py
+++ b/swaggerpy_test/client_test.py
@@ -48,7 +48,7 @@ class ClientTest(unittest.TestCase):
             httpretty.GET, "http://swagger.py/swagger-test/pet",
             body='[]')
 
-        resp = self.uut.pet.listPets()()
+        resp = self.uut.pet.listPets().result()
         self.assertEqual([], resp)
 
     @httpretty.activate
@@ -57,7 +57,7 @@ class ClientTest(unittest.TestCase):
             httpretty.GET, "http://swagger.py/swagger-test/pet/find",
             body='[]')
 
-        resp = self.uut.pet.findPets(species=['cat', 'dog'])()
+        resp = self.uut.pet.findPets(species=['cat', 'dog']).result()
         self.assertEqual([], resp)
         self.assertEqual({'species': ['cat,dog']},
                          httpretty.last_request().querystring)
@@ -69,7 +69,7 @@ class ClientTest(unittest.TestCase):
             status=requests.codes.ok,
             body='"Spark is born"')
 
-        resp = self.uut.pet.createPet(name='Sparky')()
+        resp = self.uut.pet.createPet(name='Sparky').result()
         self.assertEqual('Spark is born', resp)
         self.assertEqual({'name': ['Sparky']},
                          httpretty.last_request().querystring)
@@ -80,7 +80,7 @@ class ClientTest(unittest.TestCase):
             httpretty.DELETE, "http://swagger.py/swagger-test/pet/1234",
             status=requests.codes.no_content)
 
-        resp = self.uut.pet.deletePet(petId=1234)()
+        resp = self.uut.pet.deletePet(petId=1234).result()
         self.assertEqual(None, resp)
 
     def setUp(self):

--- a/swaggerpy_test/resource_model_test.py
+++ b/swaggerpy_test/resource_model_test.py
@@ -247,7 +247,7 @@ class ResourceTest(unittest.TestCase):
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
         resource = SwaggerClient(u'http://localhost/api-docs').api_test
-        resp = resource.testHTTP()()
+        resp = resource.testHTTP().result()
         User = resource.models.User
         School = resource.models.School
         self.assertTrue(isinstance(resp, User))
@@ -261,7 +261,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        self.assertRaises(AssertionError, SwaggerClient(u'http://localhost/api-docs').api_test.testHTTP())
+        self.assertRaises(AssertionError, SwaggerClient(u'http://localhost/api-docs').api_test.testHTTP().result)
 
     @httpretty.activate
     def test_error_on_extra_type_instead_of_complex_type(self):
@@ -270,7 +270,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        self.assertRaises(TypeError, SwaggerClient(u'http://localhost/api-docs').api_test.testHTTP())
+        self.assertRaises(TypeError, SwaggerClient(u'http://localhost/api-docs').api_test.testHTTP().result)
 
     @httpretty.activate
     def test_error_on_wrong_type_instead_of_complex_type(self):
@@ -278,7 +278,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body='"NOT_COMPLEX_TYPE"')
-        self.assertRaises(TypeError, SwaggerClient(u'http://localhost/api-docs').api_test.testHTTP())
+        self.assertRaises(TypeError, SwaggerClient(u'http://localhost/api-docs').api_test.testHTTP().result)
 
     @httpretty.activate
     def test_error_on_wrong_type_inside_complex_type(self):
@@ -287,7 +287,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        self.assertRaises(TypeError, SwaggerClient(u'http://localhost/api-docs').api_test.testHTTP())
+        self.assertRaises(TypeError, SwaggerClient(u'http://localhost/api-docs').api_test.testHTTP().result)
 
     @httpretty.activate
     def test_error_on_wrong_type_inside_nested_complex_type_2(self):
@@ -296,7 +296,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        self.assertRaises(TypeError, SwaggerClient(u'http://localhost/api-docs').api_test.testHTTP())
+        self.assertRaises(TypeError, SwaggerClient(u'http://localhost/api-docs').api_test.testHTTP().result)
 
     @httpretty.activate
     def test_error_on_missing_type_inside_nested_complex_type_1(self):
@@ -305,7 +305,7 @@ class ResourceTest(unittest.TestCase):
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        self.assertRaises(AssertionError, SwaggerClient(u'http://localhost/api-docs').api_test.testHTTP())
+        self.assertRaises(AssertionError, SwaggerClient(u'http://localhost/api-docs').api_test.testHTTP().result)
 
 
 if __name__ == '__main__':

--- a/swaggerpy_test/resource_operation_test.py
+++ b/swaggerpy_test/resource_operation_test.py
@@ -157,7 +157,7 @@ class ResourceOperationTest(unittest.TestCase):
             httpretty.GET, "http://localhost/params/42/test_http?test_param=foo",
             body='')
         resource = SwaggerClient(u'http://localhost/api-docs').api_test
-        resp = resource.testHTTP(test_param="foo", param_id="42")()
+        resp = resource.testHTTP(test_param="foo", param_id="42").result()
         self.assertEqual(None, resp)
 
     @httpretty.activate
@@ -181,7 +181,7 @@ class ResourceOperationTest(unittest.TestCase):
             httpretty.GET, "http://localhost/params/40,41,42/test_http?test_param=foo,bar",
             body='')
         resource = SwaggerClient(u'http://localhost/api-docs').api_test
-        resp = resource.testHTTP(test_params=["foo", "bar"], param_ids=[40, 41, 42])()
+        resp = resource.testHTTP(test_params=["foo", "bar"], param_ids=[40, 41, 42]).result()
         self.assertEqual(None, resp)
 
     """
@@ -223,7 +223,7 @@ class ResourceOperationTest(unittest.TestCase):
             httpretty.POST, "http://localhost/params/42/test_http?test_param=foo",
             body='')
         resource = SwaggerClient(u'http://localhost/api-docs').api_test
-        resp = resource.testHTTP(test_param="foo", param_id="42", body="some_test")()
+        resp = resource.testHTTP(test_param="foo", param_id="42", body="some_test").result()
         self.assertEqual('application/json', httpretty.last_request().headers['content-type'])
         self.assertEqual('some_test', httpretty.last_request().body)
         self.assertEqual(None, resp)
@@ -243,7 +243,7 @@ class ResourceOperationTest(unittest.TestCase):
         self.register_urls()
         httpretty.register_uri(httpretty.POST, "http://localhost/test_http", body='')
         resource = SwaggerClient(u'http://localhost/api-docs').api_test
-        resp = resource.testHTTP(body=["a", "b", "c"])()
+        resp = resource.testHTTP(body=["a", "b", "c"]).result()
         self.assertEqual(["a", "b", "c"], json.loads(httpretty.last_request().body))
         self.assertEqual(None, resp)
 

--- a/swaggerpy_test/resource_test.py
+++ b/swaggerpy_test/resource_test.py
@@ -81,7 +81,7 @@ class ResourceTest(unittest.TestCase):
             body='[]')
         self.register_urls()
         resource = SwaggerClient(u'http://localhost/api-docs').api_test
-        resp = resource.testHTTP(test_param="foo")()
+        resp = resource.testHTTP(test_param="foo").result()
         self.assertEqual([], resp)
 
     @httpretty.activate
@@ -100,7 +100,7 @@ class ResourceTest(unittest.TestCase):
         self.response["basePath"] = "http://localhost/lame/test"
         self.register_urls()
         resource = SwaggerClient(u'http://localhost/api-docs').api_test
-        resp = resource.testHTTP(test_param="foo")()
+        resp = resource.testHTTP(test_param="foo").result()
         self.assertEqual('', resp)
 
 


### PR DESCRIPTION
Implement the interface of concurrent.futures()
