### PR TITLE
Allow Python model as request body parameter.

### DIFF
--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -343,7 +343,8 @@ def validate_and_add_params_to_request(param, value, request, models):
     param_req_type = param['paramType']
 
     # Check the parameter value against its type
-    SwaggerTypeCheck(value, type_, models)
+    # And store the refined value back
+    value = SwaggerTypeCheck(value, type_, models).value
 
     if param_req_type in ('path', 'query'):
         # Parameters in path, query need to be primitive/array types

--- a/swaggerpy/swagger_model.py
+++ b/swaggerpy/swagger_model.py
@@ -10,6 +10,7 @@ import json
 import os
 import urllib
 import urlparse
+from copy import copy
 
 import swagger_type
 from swaggerpy.http_client import SynchronousHttpClient
@@ -289,7 +290,8 @@ def create_model_type(model):
     """
     props = model['properties']
     name = str(model['id'])
-    magic_methods = dict(
+    methods = dict(
+        # Magic Methods :
         # Define the docstring
         __doc__=create_model_docstring(props),
         # Make equality work for dict & type OR type & type
@@ -297,8 +299,11 @@ def create_model_type(model):
         # Define the constructor for the type
         __init__=lambda self, **kwargs: set_props(self, **kwargs),
         # Define the str repr of the type
-        __repr__=lambda self: create_model_repr(self))
-    model_type = type(name, (object,), magic_methods)
+        __repr__=lambda self: create_model_repr(self),
+        # Instance methods :
+        # Generates flat dict from the model instance
+        _flat_dict=lambda self: create_flat_dict(self))
+    model_type = type(name, (object,), methods)
     # Define a class variable to store types of its attributes
     setattr(model_type, '_swagger_types',
             swagger_type.get_swagger_types(props))
@@ -307,7 +312,6 @@ def create_model_type(model):
     return model_type
 
 
-# ToDo: Check that no required fields are None if assigned by kwargs
 def set_props(model, **kwargs):
     """Constructor for the generated type - assigns given or default values
 
@@ -385,6 +389,39 @@ def compare(first, second):
     and compares again on those dict values
     """
     return hasattr(second, '__dict__') and first.__dict__ == second.__dict__
+
+
+def create_flat_dict(model):
+    """Generates __dict__ of the model traversing recursively
+    each of the list item of an array and calling it again.
+    While __dict__ only converts it on one level.
+
+       :param model: generated model type reference
+       :type model: type
+       :returns: flat dict repr of the model
+
+       Ex: Pet(id=3, name="Name", photoUrls=["7"], tags=[Tag(id=2, name='T')])
+
+       converts to:
+        {'id': 3,
+         'name': 'Name',
+         'photoUrls': ['7'],
+         'tags': [{'id': 2, 'name': 'T'}]}
+    """
+    if not hasattr(model, '__dict__'):
+        return model
+    model_dict = copy(model.__dict__)
+    for k, v in model.__dict__.iteritems():
+        if isinstance(v, list):
+            model_dict[k] = [create_flat_dict(x) for x in v if x is not None]
+        elif v is None:
+            # Remove None values from dict to avoid their type checking
+            if k in model._required:
+                raise AttributeError("Required field %s can not be None" % k)
+            model_dict.pop(k)
+        else:
+            model_dict[k] = create_flat_dict(v)
+    return model_dict
 
 
 def create_model_repr(model):

--- a/swaggerpy/swagger_type.py
+++ b/swaggerpy/swagger_type.py
@@ -216,7 +216,7 @@ class SwaggerTypeCheck(object):
     Raises TypeError/AssertionError if validation fails
     """
 
-    def __init__(self, value, type_, models):
+    def __init__(self, value, type_, models=None):
         """Ctor to set params and then check the value
 
         :param value: JSON value
@@ -235,15 +235,16 @@ class SwaggerTypeCheck(object):
         """Check the value as per the type of the value
         """
         if self._type == 'void':
-            if self.value:
-                raise TypeError("Response %s is supposed to be empty" %
-                                self.value)
+            # Ignore any check if type is 'void'
+            return
         elif is_primitive(self._type):
             self._check_primitive_type()
         elif is_array(self._type):
             self._check_array_type()
         else:
-            self._check_complex_type()
+            # Ignore check if models tuple is not provided
+            if self.models:
+                self._check_complex_type()
 
     def _check_primitive_type(self):
         """Validate value is of primitive type
@@ -279,9 +280,8 @@ class SwaggerTypeCheck(object):
         """
         klass = getattr(self.models, self._type)
         if isinstance(self.value, klass):
-            raise AssertionError("Py instance %r not supported in Request" %
-                                 self.value)
-        # The only valid type is JSON dict
+            self.value = self.value._flat_dict()
+        # The only valid type from this point on is JSON dict
         if not isinstance(self.value, dict):
             raise TypeError("Type for %s is expected to be object" %
                             self.value)

--- a/swaggerpy_test/resource_model_test.py
+++ b/swaggerpy_test/resource_model_test.py
@@ -330,25 +330,6 @@ class ResourceTest(unittest.TestCase):
         self.assertRaises(AssertionError, SwaggerClient(
             u'http://localhost/api-docs').api_test.testHTTP())
 
-    ###############################################
-    # Raise that passing Model in request parameters
-    # is not supported for now
-    ################################################
-
-    @httpretty.activate
-    def test_error_on_passing_model_in_param_body(self):
-        query_parameter = {
-            "paramType": "body",
-            "name": "body",
-            "type": "School",
-        }
-        self.response["apis"][0]["operations"][0]["parameters"] = [
-            query_parameter]
-        self.register_urls()
-        resource = SwaggerClient(u'http://localhost/api-docs').api_test
-        school = resource.models.School()
-        self.assertRaises(AssertionError, resource.testHTTP, body=school)
-
     @httpretty.activate
     def test_error_on_passing_model_in_param_query(self):
         """Only primitive types are allowed in path or query
@@ -363,9 +344,66 @@ class ResourceTest(unittest.TestCase):
         self.register_urls()
         resource = SwaggerClient(u'http://localhost/api-docs').api_test
         school = resource.models.School()
-        # TODO: After Py model is accepted in request body,
-        # this test should then raise TypeError
-        self.assertRaises(AssertionError, resource.testHTTP, test_param=school)
+        self.assertRaises(TypeError, resource.testHTTP, test_param=school)
+
+    #################################################
+    # Model Py instance sent in request body
+    ################################################
+
+    @httpretty.activate
+    def test_success_model_in_param_body_converts_to_dict(self):
+        query_parameter = {
+            "paramType": "body",
+            "name": "body",
+            "type": "User",
+        }
+        self.response["apis"][0]["operations"][0]["parameters"] = [
+            query_parameter]
+        self.register_urls()
+        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        School = resource.models.School
+        # Also test all None items are removed from array list
+        user = resource.models.User(id=42, schools=[School(name='s1'), None])
+        future = resource.testHTTP(body=user)
+        self.assertEqual(json.dumps({'id': 42,
+                                     'schools': [{'name': 's1'}]}),
+                         future._http_client.request_params['data'])
+
+    @httpretty.activate
+    def test_removal_of_none_attributes_from_param_body_model(self):
+        query_parameter = {
+            "paramType": "body",
+            "name": "body",
+            "type": "User",
+        }
+        self.response["apis"][0]["operations"][0]["parameters"] = [
+            query_parameter]
+        self.response["models"]["User"]["properties"]["school"] = {
+            "$ref": "School"}
+        self.register_urls()
+        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        user = resource.models.User(id=42)
+        future = resource.testHTTP(body=user)
+        # Removed the 'school': None - key, value pair from dict
+        self.assertEqual(json.dumps({'id': 42, 'schools': []}),
+                         future._http_client.request_params['data'])
+
+    @httpretty.activate
+    def test_error_on_finding_required_attributes_none(self):
+        query_parameter = {
+            "paramType": "body",
+            "name": "body",
+            "type": "User",
+        }
+        self.response["apis"][0]["operations"][0]["parameters"] = [
+            query_parameter]
+        self.response["models"]["User"]["properties"]["school"] = {
+            "$ref": "School"}
+        self.response["models"]["User"]["required"] = ["school"]
+        self.register_urls()
+        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        user = resource.models.User(id=42)
+        self.assertRaises(AttributeError, resource.testHTTP, body=user)
 
     #################################################
     # Model JSON sent in request body

--- a/swaggerpy_test/resource_response_test.py
+++ b/swaggerpy_test/resource_response_test.py
@@ -140,7 +140,6 @@ class ResourceResponseTest(unittest.TestCase):
     @httpretty.activate
     def test_error_on_incorrect_primitive_types_returned(self):
         types = {
-            'void': '"NOT_EMPTY"',
             'string': '42',
             'integer': '3.4',
             'number': '42',
@@ -155,6 +154,17 @@ class ResourceResponseTest(unittest.TestCase):
             resource = SwaggerClient(u'http://localhost/api-docs').api_test
             future = resource.testHTTP(test_param="foo")
             self.assertRaises(TypeError, future)
+
+    @httpretty.activate
+    def test_success_on_returning_anything_for_type_void(self):
+        # default operation type is void
+        self.register_urls()
+        httpretty.register_uri(
+            httpretty.GET, "http://localhost/test_http?test_param=foo",
+            body='{"some_foo": "bar"}')
+        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resp = resource.testHTTP(test_param="foo")()
+        self.assertEqual({"some_foo": "bar"}, resp)
 
     # check array and datetime types
     @httpretty.activate


### PR DESCRIPTION
- Accept Py model in request body.

Swagger-py lets you build any instance of a model without any check.
But, when it is passed as a request body param, validation checks kick
in. `_flat_dict()` is used to recursively convert the model into a dict
which json can dump later.

During this conversion, type is checked against the swagger spec.
If any of the `attrs` are `None` (that happens if a default instance is
created and any of the attrs are complex) they are removed from the
dict. And if they were required for that model, Error is raised.

---
- If the response is of type None, just accept anything and do not validate.

As per: wordnik's swagger spec, operation type for pet.addPet is void
but still the response sent back is `{u'code': 200, u'message':
u'SUCCESS'}`, which has no concrete structure to check against.

Tests:

```
py26 inst-nodeps: /nail/home/prateek/pg/swagger-py/.tox/dist/swaggerpy-0.3.0.zip
py26 runtests: commands[0] | nosetests
/nail/home/prateek/pg/swagger-py/.tox/py26/lib/python2.6/site-packages/twisted/internet/endpoints.py:30: DeprecationWarning: twisted.internet.interfaces.IStreamClientEndpointStringParser was deprecated in Twisted 14.0.0: This interface has been superseded by IStreamClientEndpointStringParserWithReactor.
  from twisted.internet.interfaces import (
............................................................................................
----------------------------------------------------------------------
Ran 92 tests in 0.852s

OK
py27 inst-nodeps: /nail/home/prateek/pg/swagger-py/.tox/dist/swaggerpy-0.3.0.zip
py27 runtests: commands[0] | nosetests
............................................................................................
----------------------------------------------------------------------
Ran 92 tests in 0.684s

OK
flake8 inst-nodeps: /nail/home/prateek/pg/swagger-py/.tox/dist/swaggerpy-0.3.0.zip
flake8 runtests: commands[0] | flake8 swaggerpy
flake8 runtests: commands[1] | flake8 swaggerpy_test
_______________________________________________________________ summary _______________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  flake8: commands succeeded
  congratulations :)
```
