### PR TITLE
Add SwaggerClient proxy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ setup(
         "Programming Language :: Python",
     ],
     tests_require=["nose", "tissue", "coverage", "httpretty"],
-    install_requires=(["requests", "python-dateutil"] + websocket_packages +
-        async_packages),
+    install_requires=(["requests", "python-dateutil", "ProxyTypes"] +
+                      websocket_packages + async_packages),
     entry_points="""
     [console_scripts]
     swagger-codegen = swaggerpy.codegen:main

--- a/swaggerpy_test/resource_api_test.py
+++ b/swaggerpy_test/resource_api_test.py
@@ -28,7 +28,7 @@ import unittest
 
 import httpretty
 
-from swaggerpy.client import SwaggerClient
+from swaggerpy.client import _SwaggerClient as SwaggerClient
 from swaggerpy.processors import SwaggerError
 
 

--- a/swaggerpy_test/resource_listing_test.py
+++ b/swaggerpy_test/resource_listing_test.py
@@ -29,7 +29,7 @@ import unittest
 
 import httpretty
 
-from swaggerpy.client import SwaggerClient
+from swaggerpy.client import _SwaggerClient as SwaggerClient
 from swaggerpy.processors import SwaggerError
 
 

--- a/swaggerpy_test/resource_model_test.py
+++ b/swaggerpy_test/resource_model_test.py
@@ -52,7 +52,7 @@ import unittest
 
 import httpretty
 
-from swaggerpy.client import SwaggerClient
+from swaggerpy.client import _SwaggerClient as SwaggerClient
 from swaggerpy.processors import SwaggerError
 
 

--- a/swaggerpy_test/resource_operation_test.py
+++ b/swaggerpy_test/resource_operation_test.py
@@ -51,7 +51,7 @@ from datetime import datetime
 import httpretty
 from dateutil.tz import tzutc
 
-from swaggerpy.client import SwaggerClient
+from swaggerpy.client import _SwaggerClient as SwaggerClient
 from swaggerpy.processors import SwaggerError
 
 

--- a/swaggerpy_test/resource_response_test.py
+++ b/swaggerpy_test/resource_response_test.py
@@ -63,7 +63,7 @@ from dateutil.tz import tzutc
 from requests import HTTPError
 
 from swaggerpy.async_http_client import AsynchronousHttpClient
-from swaggerpy.client import SwaggerClient
+from swaggerpy.client import _SwaggerClient as SwaggerClient
 from swaggerpy.exception import CancelledError
 from swaggerpy.processors import SwaggerError
 from swaggerpy.response import HTTPFuture

--- a/swaggerpy_test/resource_test.py
+++ b/swaggerpy_test/resource_test.py
@@ -24,7 +24,8 @@ import unittest
 
 import httpretty
 
-from swaggerpy.client import SwaggerClient, Resource, Operation
+from swaggerpy.client import _SwaggerClient as SwaggerClient
+from swaggerpy.client import Resource, Operation
 from swaggerpy.processors import SwaggerError
 
 


### PR DESCRIPTION
SwaggerClient now wraps the core _SwaggerClient class. Each attribute call to the core is intercepted by proxy and checked for api-docs freshness first. If stale, api-docs are fetched again, and the attribute call is then passed to the core.

```
GLOB sdist-make: /nail/home/prateek/pg/swagger-py/setup.py
py26 inst-nodeps: /nail/home/prateek/pg/swagger-py/.tox/dist/swaggerpy-0.3.0.zip
py26 runtests: commands[0] | nosetests
  from twisted.internet.interfaces import (
.................................................................................................
----------------------------------------------------------------------
Ran 97 tests in 0.767s

OK
py27 inst-nodeps: /nail/home/prateek/pg/swagger-py/.tox/dist/swaggerpy-0.3.0.zip
py27 runtests: commands[0] | nosetests
.................................................................................................
----------------------------------------------------------------------
Ran 97 tests in 0.667s

OK
flake8 inst-nodeps: /nail/home/prateek/pg/swagger-py/.tox/dist/swaggerpy-0.3.0.zip
flake8 runtests: commands[0] | flake8 swaggerpy
flake8 runtests: commands[1] | flake8 swaggerpy_test
______________________________________________________________ summary ______________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  flake8: commands succeeded
  congratulations :)
```
