### PR TITLE
Fixes issue #17

### DIFF
--- a/swaggerpy/swagger_model.py
+++ b/swaggerpy/swagger_model.py
@@ -321,11 +321,13 @@ def set_props(model, **kwargs):
     for property_name, property_swagger_type in types.iteritems():
         swagger_py_type = swagger_type.swagger_to_py_type(
             property_swagger_type)
-        property_value = swagger_py_type() if swagger_py_type else None
-        # Override any property values specified in kwargs
+        # Assign all property values specified in kwargs
         if property_name in arg_keys:
             property_value = kwargs[property_name]
             arg_keys.remove(property_name)
+        else:
+            # If not in kwargs, provide a default value to the type
+            property_value = swagger_type.get_instance(swagger_py_type)
         setattr(model, property_name, property_value)
     if arg_keys:
         raise AttributeError(" %s are not defined for %s." % (arg_keys, model))

--- a/swaggerpy/swagger_type.py
+++ b/swaggerpy/swagger_type.py
@@ -51,6 +51,25 @@ ARRAY = 'array'
 COLON = ':'
 
 
+def get_instance(py_type):
+    """Factory method to get default constructor invoked for the type
+
+    ..note ::
+        get_instance() is meant to be called to get an instance of
+        primitive Python type. datetime() is called as primitive in Swagger
+        but in Python, it is not. Hence, return None for datetime instance
+
+    Complex models are already set to None in swagger_to_py_type(), hence
+    this should be called only for values from SWAGGER_TO_PY_TYPE_MAPPING
+    """
+    if py_type is None:
+        return None
+    # datetime is not a Python primitive type, return None for it.
+    if py_type == datetime:
+        return None
+    return py_type()
+
+
 def primitive_formats():
     """returns Swagger primitive formats allowed after internal conversion.
 

--- a/swaggerpy_test/resource_model_test.py
+++ b/swaggerpy_test/resource_model_test.py
@@ -137,6 +137,17 @@ class ResourceTest(unittest.TestCase):
         self.assertEqual({"schools": [], "id": 0L}, User().__dict__)
 
     @httpretty.activate
+    def test_none_for_datetime_on_model_types_creation(self):
+        self.models['User']['properties']['date'] = {
+            'type': 'string',
+            'format': 'date'}
+        self.register_urls()
+        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        User = resource.models.User
+        self.assertEqual({"schools": [], "id": 0L, "date": None},
+                         User().__dict__)
+
+    @httpretty.activate
     def test_success_on_model_types_instantiation(self):
         self.register_urls()
         resource = SwaggerClient(u'http://localhost/api-docs').api_test


### PR DESCRIPTION
`get_instance()` is meant to be called to get an instance of
primitive Python type. `datetime()` is called as primitive in Swagger
but not in Python. Hence, return None for `datetime` instance
