### PR TITLE
Add more descriptive error message

### DIFF
--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -146,8 +146,6 @@ class Operation(object):
         request['url'] = self._uri
         request['params'] = {}
         for param in self._json.get(u'parameters', []):
-            # TODO: No check on param value right now.
-            # To be done similar to checkResponse in SwaggerResponse
             value = kwargs.pop(param[u'name'], None)
             validate_and_add_params_to_request(param, value, request,
                                                self._models)
@@ -436,7 +434,7 @@ def validate_and_add_params_to_request(param, value, request, models):
     param_req_type = param['paramType']
 
     # Check the parameter value against its type
-    SwaggerTypeCheck(value, type_, models)
+    SwaggerTypeCheck(pname, value, type_, models)
 
     if param_req_type in ('path', 'query'):
         # Parameters in path, query need to be primitive/array types

--- a/swaggerpy/response.py
+++ b/swaggerpy/response.py
@@ -90,7 +90,7 @@ class SwaggerResponse(object):
         :param models: namedtuple which maps complex type string to py type
         :type models: namedtuple
         """
-        response = SwaggerTypeCheck(response, type_, models).value
+        response = SwaggerTypeCheck("Response", response, type_, models).value
         self.swagger_object = SwaggerResponseConstruct(response,
                                                        type_,
                                                        models).create_object()

--- a/swaggerpy/swagger_type.py
+++ b/swaggerpy/swagger_type.py
@@ -216,9 +216,11 @@ class SwaggerTypeCheck(object):
     Raises TypeError/AssertionError if validation fails
     """
 
-    def __init__(self, value, type_, models):
+    def __init__(self, name, value, type_, models):
         """Ctor to set params and then check the value
 
+        :param name: name of the field, used for error logging
+        :type name: str
         :param value: JSON value
         :type value: dict
         :param type_: type against which the value is to be validated
@@ -226,6 +228,7 @@ class SwaggerTypeCheck(object):
         :param models: namedtuple which maps complex type string to py type
         :type models: namedtuple
         """
+        self.name = name
         self.value = value
         self._type = type_
         self.models = models
@@ -256,8 +259,8 @@ class SwaggerTypeCheck(object):
                 self.value = dateutil.parser.parse(self.value)
             else:
                 # For all the other cases, raise Type mismatch
-                raise TypeError("Type of %s should be in %r" % (
-                    self.value, ptype))
+                raise TypeError("%s's value: %s should be in types %r" % (
+                    self.name, self.value, ptype))
 
     def _check_array_type(self):
         """Validate array type value is actually array type
@@ -270,6 +273,7 @@ class SwaggerTypeCheck(object):
                             self.value.__class__.__name__)
         array_item_type = get_array_item_type(self._type)
         self.value = [SwaggerTypeCheck(
+            "%s's item" % self.name,
             item, array_item_type, self.models).value
             for item in self.value]
 
@@ -291,7 +295,8 @@ class SwaggerTypeCheck(object):
                 required.remove(key)
             if key not in klass._swagger_types.keys():
                 raise TypeError("Type for '%s' was not defined in spec." % key)
-            self.value[key] = SwaggerTypeCheck(self.value[key],
+            self.value[key] = SwaggerTypeCheck(key,
+                                               self.value[key],
                                                klass._swagger_types[key],
                                                self.models).value
         if required:


### PR DESCRIPTION
Change error message to a more descriptive message (include name of the culprit parameter)

Old message: `Type of None should be in (<type 'str'>, <type 'unicode'>)`

New message: `q's value: None should be in types (<type 'str'>, <type 'unicode'>)`
