### PR TITLE
Fixes #22

### DIFF
--- a/swaggerpy/async_http_client.py
+++ b/swaggerpy/async_http_client.py
@@ -30,7 +30,13 @@ log = logging.getLogger(__name__)
 
 class AsynchronousHttpClient(http_client.HttpClient):
     """Asynchronous HTTP client implementation.
+
+    :param headers: headers to be sent with the requests
+    :type headers: dict
     """
+
+    def __init__(self, headers={}):
+        self._headers = headers
 
     def setup(self, request_params):
         """Sets up the request params as per Twisted Agent needs.

--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -145,7 +145,9 @@ class Operation(object):
         request['method'] = self._json[u'method']
         request['url'] = self._uri
         request['params'] = {}
-        request['headers'] = {}
+        # Copy the client's headers so that other headers could
+        # be added during this construction w/o changing the former
+        request['headers'] = self._http_client._headers.copy()
         for param in self._json.get(u'parameters', []):
             # TODO: No check on param value right now.
             # To be done similar to checkResponse in SwaggerResponse

--- a/swaggerpy/http_client.py
+++ b/swaggerpy/http_client.py
@@ -179,10 +179,11 @@ class SynchronousHttpClient(HttpClient):
     """Synchronous HTTP client implementation.
     """
 
-    def __init__(self):
+    def __init__(self, headers={}):
         self.session = requests.Session()
         self.authenticator = None
         self.websockets = set()
+        self._headers = headers
 
     def close(self):
         self.session.close()

--- a/swaggerpy_test/client_test.py
+++ b/swaggerpy_test/client_test.py
@@ -14,6 +14,7 @@ import requests
 from mock import patch
 
 from swaggerpy import client
+from swaggerpy.http_client import SynchronousHttpClient
 from swaggerpy.client import SwaggerClient, SwaggerClientFactory
 
 
@@ -118,6 +119,17 @@ class ClientTest(unittest.TestCase):
             self.fail("Expected type error")
         except TypeError:
             pass
+
+    @httpretty.activate
+    def test_headers(self):
+        self.uut = SwaggerClient(self.resource_listing,
+                                 SynchronousHttpClient(headers={'foo': 'bar'}))
+        httpretty.register_uri(
+            httpretty.GET, "http://swagger.py/swagger-test/pet",
+            body='[]')
+
+        self.uut.pet.listPets().result()
+        self.assertEqual('bar', httpretty.last_request().headers['foo'])
 
     @httpretty.activate
     def test_get(self):


### PR DESCRIPTION
This will allow to add custom headers to the request like so:

``` python
headers = {'foo': 'bar'}
client = swaggerpy.client.get_client('/api-docs/', AsynchronousHttpClient(headers=headers))
```
