### PR TITLE
Convert query params to multi dict instead of comma separated values

### DIFF
--- a/swaggerpy/async_http_client.py
+++ b/swaggerpy/async_http_client.py
@@ -51,7 +51,7 @@ class AsynchronousHttpClient(http_client.HttpClient):
             'bodyProducer': stringify_body(request_params),
             'headers': listify_headers(request_params.get('headers')),
             'uri': str(request_params['url'] + '?' + urllib.urlencode(
-                request_params['params']))
+                request_params['params'], True))
         }
 
         crochet.setup()

--- a/swaggerpy_test/client_test.py
+++ b/swaggerpy_test/client_test.py
@@ -148,7 +148,7 @@ class ClientTest(unittest.TestCase):
 
         resp = self.uut.pet.findPets(species=['cat', 'dog']).result()
         self.assertEqual([], resp)
-        self.assertEqual({'species': ['cat,dog']},
+        self.assertEqual({'species': ['cat', 'dog']},
                          httpretty.last_request().querystring)
 
     @httpretty.activate
@@ -227,10 +227,7 @@ class ClientTest(unittest.TestCase):
                                             {
                                                 "name": "species",
                                                 "paramType": "query",
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "string"
-                                                },
+                                                "type": "string",
                                                 "allowMultiple": True
                                             }
                                         ]


### PR DESCRIPTION
- Allow only primitive types for query parameters. That means `type: array` is not allowed for query params.
- Allow both foo='x' or foo=['x','y'] for query params if `type: string` is provided. This will be converted to params: {'foo': ['x','y']} which will be handled as `foo=x&foo=y` by requests and async client (tests are present for requests and manually tested for async client).
- `path` params will remain the same. That means foo=['x','y'] will be allowed if type is `array` and will be converted to comma separated. That means this will still work : `foo/{foo}/..` to `foo/x,y/...`
