### PR TITLE
Raise more detailed error message by including the server response sent

### DIFF
--- a/swaggerpy/response.py
+++ b/swaggerpy/response.py
@@ -48,7 +48,16 @@ class HTTPFuture(object):
         if self.cancelled():
             raise CancelledError()
         response = self._http_client.wait(timeout)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except IOError as e:
+            if hasattr(e, 'response') and hasattr(e.response, 'text'):
+                # e.args is a tuple, change to list for modifications
+                args = list(e.args)
+                args[0] += (' : ' + e.response.text)
+                e.args = tuple(args)
+            raise
+
         return self._postHTTP_callback(response)
 
 

--- a/swaggerpy_test/client_test.py
+++ b/swaggerpy_test/client_test.py
@@ -141,6 +141,18 @@ class ClientTest(unittest.TestCase):
         self.assertEqual([], resp)
 
     @httpretty.activate
+    def test_response_body_is_shown_in_error_message(self):
+        httpretty.register_uri(
+            httpretty.GET, "http://swagger.py/swagger-test/pet",
+            body='{"success": false}', status=500)
+        msg = '500 Server Error: Internal Server Error'
+
+        try:
+            self.uut.pet.listPets().result()
+        except IOError as e:
+            self.assertEqual(msg + ' : {"success": false}', e.args[0])
+
+    @httpretty.activate
     def test_multiple(self):
         httpretty.register_uri(
             httpretty.GET, "http://swagger.py/swagger-test/pet/find",


### PR DESCRIPTION
Earlier error trace:

```
---------------------------------------------------------------------------
HTTPError                                 Traceback (most recent call last)
<ipython-input-17-31c82c47c84d> in <module>()
----> 1 r2.raise_for_status()

/nail/home/prateek/pg/mypy/lib/python2.6/site-packages/requests/models.pyc in raise_for_status(self)
    793
    794         if http_error_msg:
--> 795             raise HTTPError(http_error_msg, response=self)
    796
    797     def close(self):

HTTPError: 500 Server Error: Internal Server Error
```

Newer error trace: (added **{"reason": "File is not a zip file", "error": "zipfile.BadZipfile"}** )

```
/nail/home/prateek/pg/swagger-py/swaggerpy/response.pyc in result(self, timeout)
     50         response = self._http_client.wait(timeout)
     51         try:
---> 52             response.raise_for_status()
     53         except IOError as e:
     54             args = list(e.args)

/nail/home/prateek/pg/mypy/lib/python2.6/site-packages/requests/models.pyc in raise_for_status(self)
    793
    794         if http_error_msg:
--> 795             raise HTTPError(http_error_msg, response=self)
    796
    797     def close(self):

HTTPError: 500 Server Error: Internal Server Error : {"reason": "File is not a zip file", "error": "zipfile.BadZipfile"}
```
