### PR TITLE
Pass defaultValue if param not passed during api call.

### DIFF
--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -149,7 +149,7 @@ class Operation(object):
         # be added during this construction w/o changing the former
         request['headers'] = self._http_client._headers.copy()
         for param in self._json.get(u'parameters', []):
-            value = kwargs.pop(param[u'name'], None)
+            value = kwargs.pop(param[u'name'], default_value(param))
             validate_and_add_params_to_request(param, value, request,
                                                self._models)
         if kwargs:
@@ -419,6 +419,13 @@ def add_param_to_req(param, value, request):
     else:
         raise AssertionError(
             u"Unsupported Parameter type: %s" % param_req_type)
+
+
+def default_value(param):
+    """Fetches if present for param, returns None otherwise
+    Validation of the type happens later.
+    """
+    return param.get('defaultValue')
 
 
 def validate_and_add_params_to_request(param, value, request, models):

--- a/swaggerpy_test/resource_operation_test.py
+++ b/swaggerpy_test/resource_operation_test.py
@@ -178,6 +178,17 @@ class ResourceOperationTest(unittest.TestCase):
         self.assertEqual(None, resp)
 
     @httpretty.activate
+    def test_success_on_passing_default_value_if_param_not_passed(self):
+        self.parameter['defaultValue'] = 'testString'
+        self.register_urls()
+        httpretty.register_uri(httpretty.GET,
+                               "http://localhost/test_http?", body='')
+        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource.testHTTP().result()
+        self.assertEqual(['testString'],
+                         httpretty.last_request().querystring['test_param'])
+
+    @httpretty.activate
     def test_success_on_get_with_array_in_path_and_query_params(self):
         query_parameter = {
             "paramType": "query",


### PR DESCRIPTION
If an `operation` has a `parameter`, with a `defaultValue` in the schema, then that value will be used if `parameter` not passed during the api call.

 Fixes #28
