### PR TITLE
Append Base Path, if relative, to the host_name path

### DIFF
--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -256,13 +256,13 @@ class Resource(object):
         """
         log.debug(u"Building operation %s.%s" % (
             self._get_name(), operation[u'nickname']))
-        # If basePath is root, use the basePath stored during init
-        if decl[u'basePath'] == '/':
+        # IF basePath starts with /, prepend it with stored host name
+        if decl[u'basePath'].startswith('/'):
             if urlparse(self._base_path).scheme == 'file':
                 raise AssertionError(
-                    "Base path can't be / for local specs." +
-                    " Pass api_base_path param to SwaggerClient.")
-            base_path = self._base_path
+                    "Base path can't start with / for local specs," +
+                    " unless api_base_path is passed to SwaggerClient.")
+            base_path = self._base_path.strip('/') + decl['basePath']
         else:
             base_path = decl[u'basePath']
         uri = base_path.strip('/') + api[u'path']

--- a/swaggerpy_test/resource_test.py
+++ b/swaggerpy_test/resource_test.py
@@ -89,6 +89,18 @@ class ResourceTest(unittest.TestCase):
         self.assertEqual([], resp)
 
     @httpretty.activate
+    def test_append_base_path_if_base_path_isnt_absolute(self):
+        self.response["basePath"] = "/append"
+        httpretty.register_uri(
+            httpretty.GET, "http://localhost/append/test_http?",
+            body='[]')
+        self.register_urls()
+        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resource.testHTTP(test_param="foo").result()
+        self.assertEqual(["foo"],
+                         httpretty.last_request().querystring['test_param'])
+
+    @httpretty.activate
     def test_setattrs_on_client_and_resource(self):
         self.register_urls()
         client = SwaggerClient(u'http://localhost/api-docs')


### PR DESCRIPTION
If the basePath is `/internalapi` and the path is `/v1/business?`, then the final api path will be `/internalapi/v1/business?` [This is outside v1.2 and more of an extra feature to accommodate `internalapi` endpoints.
