### PR TITLE
Allow Null Response if allow_null is passed

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -105,7 +105,11 @@ will result in error like so:
 
 .. code-block:: console
 
-        TypeError: id's value: I should be integer :( should be in types (<type 'long'>, <type 'int'>)
+        TypeError: id's value: 'I should be integer :(' should be in types (<type 'long'>, <type 'int'>)
+
+.. note::
+
+       If you think it is acceptable for fields in your response to be null, and want the validator to ignore the type check you can add ``allow_null=True`` as a parameter to ``result()``.
 
 Caching
 -------

--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -166,7 +166,7 @@ class Operation(object):
             raise AssertionError("Websockets aren't supported in this version")
         request = self._construct_request(**kwargs)
 
-        def py_model_convert_callback(response):
+        def py_model_convert_callback(response, **kwargs):
             value = None
             type_ = swagger_type.get_swagger_type(self._json)
             # Assume status is OK,
@@ -175,7 +175,8 @@ class Operation(object):
             if response.text:
                 # Validate and convert API response to Python model instance
                 value = SwaggerResponse(
-                    response.json(), type_, self._models).swagger_object
+                    response.json(), type_, self._models,
+                    **kwargs).swagger_object
             return value
         return HTTPFuture(self._http_client,
                           request, py_model_convert_callback)

--- a/swaggerpy/response.py
+++ b/swaggerpy/response.py
@@ -40,16 +40,22 @@ class HTTPFuture(object):
         self._cancelled = True
         self._http_client.cancel()
 
-    def result(self, timeout=DEFAULT_TIMEOUT_S):
+    def result(self, **kwargs):
         """Blocking call to wait for API response
         If API was cancelled earlier, CancelledError is raised
         If everything goes fine, callback registered is triggered with response
+
+        :param timeout: timeout in seconds to wait for response
+        :type timeout: integer
+        :param allow_null: if True, allow null fields in response
+        :type allow_null: boolean
         """
+        timeout = kwargs.pop('timeout', DEFAULT_TIMEOUT_S)
         if self.cancelled():
             raise CancelledError()
         response = self._http_client.wait(timeout)
         response.raise_for_status()
-        return self._postHTTP_callback(response)
+        return self._postHTTP_callback(response, **kwargs)
 
 
 class SwaggerResponse(object):
@@ -83,7 +89,7 @@ class SwaggerResponse(object):
 
     """
 
-    def __init__(self, response, type_, models):
+    def __init__(self, response, type_, models, **kwargs):
         """Wrapper to check and construt swagger response instance from API response
 
         :param response: JSON response
@@ -93,7 +99,9 @@ class SwaggerResponse(object):
         :param models: namedtuple which maps complex type string to py type
         :type models: namedtuple
         """
-        response = SwaggerTypeCheck("Response", response, type_, models).value
+        allow_null = kwargs.pop('allow_null', False)
+        response = SwaggerTypeCheck("Response", response, type_, models,
+                                    allow_null).value
         self.swagger_object = SwaggerResponseConstruct(response,
                                                        type_,
                                                        models).create_object()


### PR DESCRIPTION
If `allow_null` is passed, the `null` values are allowed. If `Pet` has `name: None`, even then `client.pet.getPetById(petId=2).result(allow_null=True)` is acceptable. If the param is not provided, swagger-py will fail the validations.
