### PR TITLE
Relax validation rules just a little bit.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+0.5.7 (2014-10-23)
+------------------
+- Successfully validate objects that have additional fields beyond those
+  specified in the associated model.
+- Store raw deserialized JSON in '_raw' attribute of objects.
+- Ignore '_raw' attribute in object equality checks.
+
 0.2.0 (2013-10-28)
 ------------------
 - Add close() methods to client and http_client.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ async_packages = ["crochet", "twisted"]
 
 setup(
     name="swaggerpy",
-    version="0.5.6",
+    version="0.5.7",
     license="BSD 3-Clause License",
     description="Library for accessing Swagger-enabled API's",
     long_description=open(os.path.join(os.path.dirname(__file__),

--- a/swaggerpy/response.py
+++ b/swaggerpy/response.py
@@ -182,8 +182,13 @@ class SwaggerResponseConstruct(object):
         """
         klass = getattr(self._models, self._type)
         instance = klass()
+        setattr(instance, '_raw', self._response)
         for key in self._response.keys():
-            type_ = klass._swagger_types[key]
+            type_ = klass._swagger_types.get(key)
+            if type_ is None:
+                # Ignore unrecognized keys.  They will still be accessible in
+                # the '_raw' field if needed.
+                continue
             swagger_response = SwaggerResponseConstruct(self._response[key],
                                                         type_,
                                                         self._models)

--- a/swaggerpy/swagger_model.py
+++ b/swaggerpy/swagger_model.py
@@ -395,7 +395,14 @@ def compare(first, second):
     If a type composes another model types, .__dict__ recurse on those
     and compares again on those dict values
     """
-    return hasattr(second, '__dict__') and first.__dict__ == second.__dict__
+    if not hasattr(second, '__dict__'):
+        return False
+
+    # Ignore any '_raw' keys
+    def norm_dict(d):
+        return dict((k, d[k]) for k in d if k != '_raw')
+
+    return norm_dict(first.__dict__) == norm_dict(second.__dict__)
 
 
 def create_flat_dict(model):

--- a/swaggerpy/swagger_type.py
+++ b/swaggerpy/swagger_type.py
@@ -331,7 +331,8 @@ class SwaggerTypeCheck(object):
             if key in required:
                 required.remove(key)
             if key not in klass._swagger_types.keys():
-                raise TypeError("Type for '%s' was not defined in spec." % key)
+                # Ignore unrecognized keys
+                continue
             self.value[key] = SwaggerTypeCheck(key,
                                                self.value[key],
                                                klass._swagger_types[key],

--- a/tests/resource_model_test.py
+++ b/tests/resource_model_test.py
@@ -293,14 +293,15 @@ class ResourceTest(unittest.TestCase):
             u'http://localhost/api-docs').api_test.testHTTP().result)
 
     @httpretty.activate
-    def test_error_on_extra_type_instead_of_complex_type(self):
+    def test_success_on_extra_field_in_complex_type(self):
         self.register_urls()
         self.sample_model["extra"] = 42
         httpretty.register_uri(
             httpretty.GET, "http://localhost/test_http",
             body=json.dumps(self.sample_model))
-        self.assertRaises(TypeError, SwaggerClient(
-            u'http://localhost/api-docs').api_test.testHTTP().result)
+        result = SwaggerClient(
+            u'http://localhost/api-docs').api_test.testHTTP().result()
+        self.assertEqual(result._raw["extra"], 42)
 
     @httpretty.activate
     def test_error_on_wrong_type_instead_of_complex_type(self):


### PR DESCRIPTION
- Successfully validate dicts that have additional fields beyond those
  specified in the associated model.
- Store raw deserialized JSON in '_raw' attribute of objects.
- Ignore '_raw' attribute in object equality checks.
