### PR TITLE
change format='date' objects to use datetime.date representation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+0.6.0 (2014-10-30)
+------------------
+- format='date' params are now represented and passed as
+  datetime.date objects instead of datetime.datetimes.
+
 0.5.7 (2014-10-23)
 ------------------
 - Successfully validate objects that have additional fields beyond those

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ async_packages = ["crochet", "twisted"]
 
 setup(
     name="swaggerpy",
-    version="0.5.7",
+    version="0.6.0",
     license="BSD 3-Clause License",
     description="Library for accessing Swagger-enabled API's",
     long_description=open(os.path.join(os.path.dirname(__file__),

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -7,6 +7,7 @@
 """Swagger client tests.
 """
 
+import datetime
 import json
 import unittest
 
@@ -184,12 +185,17 @@ class ClientTest(unittest.TestCase):
                          httpretty.last_request().querystring)
 
     @httpretty.activate
-    def test_post(self):
+    def test_post_and_optional_params(self):
         httpretty.register_uri(
             httpretty.POST, "http://swagger.py/swagger-test/pet",
             status=requests.codes.ok,
             body='"Spark is born"')
 
+        resp = self.uut.pet.createPet(
+            name='Sparky', birthday=datetime.date(2014, 1, 2)).result()
+        self.assertEqual('Spark is born', resp)
+        self.assertEqual({'name': ['Sparky'], 'birthday': ['2014-01-02']},
+                         httpretty.last_request().querystring)
         resp = self.uut.pet.createPet(name='Sparky').result()
         self.assertEqual('Spark is born', resp)
         self.assertEqual({'name': ['Sparky']},
@@ -226,7 +232,7 @@ class ClientTest(unittest.TestCase):
                                         "nickname": "listPets",
                                         "type": "array",
                                         "items": {
-                                                "type": "string"
+                                            "type": "string"
                                         },
                                         "parameters": []
                                     },
@@ -240,6 +246,13 @@ class ClientTest(unittest.TestCase):
                                                 "paramType": "query",
                                                 "type": "string",
                                                 "required": True
+                                            },
+                                            {
+                                                "name": "birthday",
+                                                "paramType": "query",
+                                                "type": "string",
+                                                "format": "date",
+                                                "required": False
                                             }
                                         ]
                                     }
@@ -253,7 +266,7 @@ class ClientTest(unittest.TestCase):
                                         "nickname": "findPets",
                                         "type": "array",
                                         "items": {
-                                                "type": "string"
+                                            "type": "string"
                                         },
                                         "parameters": [
                                             {

--- a/tests/resource_model_test.py
+++ b/tests/resource_model_test.py
@@ -137,15 +137,20 @@ class ResourceTest(unittest.TestCase):
         self.assertEqual({"schools": [], "id": 0L}, User().__dict__)
 
     @httpretty.activate
-    def test_none_for_datetime_on_model_types_creation(self):
+    def test_nones_for_dates_on_model_types_creation(self):
         self.models['User']['properties']['date'] = {
             'type': 'string',
             'format': 'date'}
+        self.models['User']['properties']['datetime'] = {
+            'type': 'string',
+            'format': 'date-time'}
         self.register_urls()
         resource = SwaggerClient(u'http://localhost/api-docs').api_test
         User = resource.models.User
-        self.assertEqual({"schools": [], "id": 0L, "date": None},
-                         User().__dict__)
+        self.assertEqual(
+            {"schools": [], "id": 0L, "date": None, "datetime": None},
+            User().__dict__
+        )
 
     @httpretty.activate
     def test_success_on_model_types_instantiation(self):

--- a/tests/resource_operation_test.py
+++ b/tests/resource_operation_test.py
@@ -44,10 +44,10 @@ A sample 'peration' is listed below in 'operations' list.
 }
 """
 
+import datetime
 import json
 import unittest
 import urlparse
-from datetime import datetime
 
 import httpretty
 from dateutil.tz import tzutc
@@ -341,9 +341,29 @@ class ResourceOperationTest(unittest.TestCase):
             httpretty.GET, "http://localhost/test_http", body='')
         self.register_urls()
         resource = SwaggerClient(u'http://localhost/api-docs').api_test
-        some_date = datetime(2014, 6, 10, 23, 49, 54, 728000, tzinfo=tzutc())
-        resource.testHTTP(test_param=some_date).result()
+        some_datetime = datetime.datetime(
+            2014, 6, 10, 23, 49, 54, 728000, tzinfo=tzutc())
+        resource.testHTTP(test_param=some_datetime).result()
         self.assertEqual(['2014-06-10 23:49:54.728000 00:00'],
+                         httpretty.last_request().querystring['test_param'])
+
+    @httpretty.activate
+    def test_success_on_passing_date_in_param(self):
+        query_parameter = {
+            "paramType": "query",
+            "name": "test_param",
+            "type": "string",
+            "format": "date"
+        }
+        self.response["apis"][0]["operations"][0]["parameters"] = [
+            query_parameter]
+        httpretty.register_uri(
+            httpretty.GET, "http://localhost/test_http", body='')
+        self.register_urls()
+        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        some_date = datetime.date(2014, 6, 10)
+        resource.testHTTP(test_param=some_date).result()
+        self.assertEqual(['2014-06-10'],
                          httpretty.last_request().querystring['test_param'])
 
     @httpretty.activate

--- a/tests/resource_response_test.py
+++ b/tests/resource_response_test.py
@@ -53,9 +53,9 @@ is validated against its type 'Pet' which is defined like so:
 }
 """
 
+import datetime
 import json
 import unittest
-from datetime import datetime
 from mock import patch, Mock
 
 import httpretty
@@ -210,6 +210,18 @@ class ResourceResponseTest(unittest.TestCase):
         resp = resource.testHTTP(test_param="foo").result(raw_response=True)
         self.assertEqual({"some_foo": "bar"}, resp)
 
+    @httpretty.activate
+    def test_success_on_date_type(self):
+        self.response["apis"][0]["operations"][0]["type"] = "string"
+        self.response["apis"][0]["operations"][0]["format"] = "date"
+        self.register_urls()
+        httpretty.register_uri(
+            httpretty.GET, "http://localhost/test_http?test_param=foo",
+            body='"2014-06-10"')
+        resource = SwaggerClient(u'http://localhost/api-docs').api_test
+        resp = resource.testHTTP(test_param="foo").result()
+        self.assertEqual(resp, datetime.date(2014, 6, 10))
+
     # check array and datetime types
     @httpretty.activate
     def test_success_on_correct_array_type_returned_by_operation(self):
@@ -224,7 +236,7 @@ class ResourceResponseTest(unittest.TestCase):
             body='["2014-06-10T23:49:54.728+0000"]')
         resource = SwaggerClient(u'http://localhost/api-docs').api_test
         resp = resource.testHTTP(test_param="foo").result()
-        self.assertEqual(resp, [datetime(
+        self.assertEqual(resp, [datetime.datetime(
             2014, 6, 10, 23, 49, 54, 728000, tzinfo=tzutc())])
 
     @httpretty.activate


### PR DESCRIPTION
The key effect of this change, in case it wasn't clear, is that the client will now generate query params like '?date=2014-10-24' instead of '?date=2014-10-29+00%3A00%3A00' for params with a 'date' type.
