### PR TITLE
Headers can be specified only at request time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ async_packages = ["crochet", "twisted"]
 
 setup(
     name="swaggerpy",
-    version="0.6.1",
+    version="0.7.0",
     license="BSD 3-Clause License",
     description="Library for accessing Swagger-enabled API's",
     long_description=open(os.path.join(os.path.dirname(__file__),

--- a/swaggerpy/async_http_client.py
+++ b/swaggerpy/async_http_client.py
@@ -31,13 +31,7 @@ log = logging.getLogger(__name__)
 
 class AsynchronousHttpClient(http_client.HttpClient):
     """Asynchronous HTTP client implementation.
-
-    :param headers: headers to be sent with the requests
-    :type headers: dict
     """
-
-    def __init__(self, headers={}):
-        self._headers = headers
 
     def setup(self, request_params):
         """Sets up the request params as per Twisted Agent needs.
@@ -46,13 +40,11 @@ class AsynchronousHttpClient(http_client.HttpClient):
         :param request_params: request parameters for API call
         :type request_params: dict
         """
-        # request_params has mandatory: method, url, params
-        if not request_params.get('headers'):
-            request_params['headers'] = self._headers
+        # request_params has mandatory: method, url, params, headers
         self.request_params = {
             'method': str(request_params['method']),
             'bodyProducer': stringify_body(request_params),
-            'headers': listify_headers(request_params.get('headers')),
+            'headers': listify_headers(request_params['headers']),
             'uri': str(request_params['url'] + '?' + urllib.urlencode(
                 request_params['params'], True))
         }
@@ -169,7 +161,7 @@ class _HTTPBodyFetcher(Protocol):
 def stringify_body(request_params):
     """Wraps the data using twisted FileBodyProducer
     """
-    headers = request_params.get('headers', {}) or {}
+    headers = request_params['headers']
     if 'files' in request_params:
         data = create_multipart_content(request_params, headers)
     elif headers.get('content-type') == http_client.APP_FORM:
@@ -183,7 +175,6 @@ def stringify_body(request_params):
 def listify_headers(headers):
     """Twisted agent requires header values as lists
     """
-    headers = headers or {}
     for key, val in headers.iteritems():
         if not isinstance(val, list):
             headers[key] = [val]

--- a/swaggerpy/http_client.py
+++ b/swaggerpy/http_client.py
@@ -168,20 +168,18 @@ class SynchronousHttpClient(HttpClient):
     """Synchronous HTTP client implementation.
     """
 
-    def __init__(self, headers={}):
+    def __init__(self):
         self.session = requests.Session()
         self.authenticator = None
-        self._headers = headers
 
     def close(self):
         self.session.close()
 
     def setup(self, request_params):
-        headers = request_params.get('headers', {}) or {}
         # if files in request_params OR
         # if content-type is x-www-form-urlencoded, no need to stringify
         if ('files' not in request_params and
-                headers.get('content-type') != APP_FORM):
+                request_params['headers'].get('content-type') != APP_FORM):
             stringify_body(request_params)
         self.request_params = request_params
         self.purge_content_types_if_file_present()
@@ -215,8 +213,7 @@ class SynchronousHttpClient(HttpClient):
         like application/x-www-form... should be removed
         """
         if 'files' in self.request_params:
-            headers = self.request_params.get('headers', {}) or {}
-            headers.pop('content-type', '')
+            self.request_params['headers'].pop('content-type', '')
 
     def cancel(self):
         """Nothing to be done for Synchronous client
@@ -229,7 +226,7 @@ class SynchronousHttpClient(HttpClient):
         :rtype:  requests.Response
         """
         if not headers:
-            headers = self._headers
+            headers = {}
         kwargs = {}
         for i in ('method', 'url', 'params', 'data', 'headers'):
             kwargs[i] = locals()[i]

--- a/tests/async_http_client_test.py
+++ b/tests/async_http_client_test.py
@@ -55,12 +55,12 @@ class AsyncHttpClientTest(unittest.TestCase):
                        return_value='foo') as mock_stringIO:
                 with patch('swaggerpy.async_http_client.FileBodyProducer',
                            return_value='mock_fbp') as mock_fbp:
-                    resp = swaggerpy.async_http_client.stringify_body(
-                        {'data': 42})
+                    body = {'data': 42, 'headers': {}}
+                    resp = swaggerpy.async_http_client.stringify_body(body)
 
                     self.assertEqual('mock_fbp', resp)
 
-                    mock_stringify.assert_called_once_with({'data': 42})
+                    mock_stringify.assert_called_once_with(body)
                     mock_stringIO.assert_called_once_with(42)
                     mock_fbp.assert_called_once_with('foo')
 
@@ -113,12 +113,11 @@ class AsyncHttpClientTest(unittest.TestCase):
                 'method': 'GET',
                 'url': 'foo',
                 'data': None,
-                'headers': None,
+                'headers': {'foo': 'bar'},
                 'params': ''}
             mock_Async.return_value.wait.return_value = Response(
                 1, 2, 3, 4, 5, 6)
-            async_client = swaggerpy.async_http_client.AsynchronousHttpClient(
-                headers={'foo': 'bar'})
+            async_client = swaggerpy.async_http_client.AsynchronousHttpClient()
             async_client.setup(req)
             resp = async_client.wait(5)
             headers = async_client.request_params['headers']

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -156,14 +156,29 @@ class ClientTest(unittest.TestCase):
 
     @httpretty.activate
     def test_headers(self):
-        self.uut = SwaggerClient(self.resource_listing,
-                                 SynchronousHttpClient(headers={'foo': 'bar'}))
+        self.uut = SwaggerClient(
+            self.resource_listing, SynchronousHttpClient())
         httpretty.register_uri(
             httpretty.GET, "http://swagger.py/swagger-test/pet",
             body='[]')
 
-        self.uut.pet.listPets().result()
+        self.uut.pet.listPets(
+            _request_options={'headers': {'foo': 'bar'}}).result()
         self.assertEqual('bar', httpretty.last_request().headers['foo'])
+
+    @httpretty.activate
+    def test_multiple_headers(self):
+        self.uut = SwaggerClient(
+            self.resource_listing, SynchronousHttpClient())
+        httpretty.register_uri(
+            httpretty.GET, "http://swagger.py/swagger-test/pet",
+            body='[]')
+
+        self.uut.pet.listPets(
+            _request_options={'headers': {'foo': 'bar', 'sweet': 'bike'}},
+        ).result()
+        self.assertEqual('bar', httpretty.last_request().headers['foo'])
+        self.assertEqual('bike', httpretty.last_request().headers['sweet'])
 
     @httpretty.activate
     def test_raise_with_wrapper(self):

--- a/tests/resource_listing_test.py
+++ b/tests/resource_listing_test.py
@@ -30,8 +30,6 @@ import unittest
 import httpretty
 
 from swaggerpy.client import SwaggerClient
-from swaggerpy.http_client import SynchronousHttpClient
-from swaggerpy.async_http_client import AsynchronousHttpClient
 from swaggerpy.processors import SwaggerError
 
 
@@ -81,23 +79,6 @@ class ResourceListingTest(unittest.TestCase):
         self.client = SwaggerClient(u'http://localhost/api-docs')
         self.assertNotEqual(None, self.client)
 
-    @httpretty.activate
-    def test_headers_present_when_loading_resource_through_Synchronous(self):
-        self.response['apis'] = []
-        self.register_urls()
-        sync_http_client = SynchronousHttpClient(headers={'foo': 'bar'})
-        SwaggerClient(u'http://localhost/api-docs',
-                      http_client=sync_http_client)
-        self.assertEqual('bar', httpretty.last_request().headers['foo'])
-
-    @httpretty.activate
-    def test_headers_present_when_loading_resource_through_Asynchronous(self):
-        self.response['apis'] = []
-        self.register_urls()
-        async_http_client = AsynchronousHttpClient(headers={'foo': 'bar'})
-        SwaggerClient(u'http://localhost/api-docs',
-                      http_client=async_http_client)
-        self.assertEqual('bar', httpretty.last_request().headers['foo'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #64

Headers aren't something that's particularly good to cache, as they don't require that HTTP call, and it can lead to especially subtle / hard to debug issues (I know because I had the issue).
This reserves the key _request_options in case we need similar things in the future.

This is backwards incompatible as it will break client instantiation that specified headers.
