### PR TITLE
Allow headers to be sent with api doc request

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ async_packages = ["crochet", "twisted"]
 
 setup(
     name="swaggerpy",
-    version="0.7.1",
+    version="0.7.2",
     license="BSD 3-Clause License",
     description="Library for accessing Swagger-enabled API's",
     long_description=open(os.path.join(os.path.dirname(__file__),

--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -291,7 +291,8 @@ class SwaggerClient(object):
     """
 
     def __init__(self, url_or_resource, http_client=None,
-                 api_base_path=None, raise_with=None):
+                 api_base_path=None, raise_with=None,
+                 api_doc_request_headers=None):
         if not http_client:
             http_client = SynchronousHttpClient()
         # Wrap http client's errors with raise_with
@@ -301,7 +302,9 @@ class SwaggerClient(object):
         # Load Swagger APIs always synchronously
         loader = Loader(
             SynchronousHttpClient(),
-            [ClientProcessor()])
+            [ClientProcessor()],
+            api_doc_request_headers=api_doc_request_headers,
+        )
 
         forced_api_base_path = api_base_path is not None
         # url_or_resource can be url of type str,

--- a/tests/resource_test.py
+++ b/tests/resource_test.py
@@ -108,6 +108,19 @@ class ResourceTest(unittest.TestCase):
         self.assertTrue(isinstance(client.api_test.testHTTP, Operation))
 
     @httpretty.activate
+    def test_headers_sendable_with_api_doc_request(self):
+        self.register_urls()
+        SwaggerClient(
+            u'http://localhost/api-docs',
+            api_doc_request_headers={'foot': 'bart'},
+        )
+
+        self.assertEqual(
+            'bart',
+            httpretty.last_request().headers.get('foot'),
+        )
+
+    @httpretty.activate
     def test_api_base_path_if_passed_is_always_used_as_base_path(self):
         httpretty.register_uri(
             httpretty.GET, "http://foo/test_http?", body='')


### PR DESCRIPTION
Solves #71.

At some point we need to do this better and unify the way these requests are generated. SynchronousHttpClient shouldn't need the .request method
