### PR TITLE
Use client to fetch, resolve body and content issues

### DIFF
--- a/swaggerpy/async_http_client.py
+++ b/swaggerpy/async_http_client.py
@@ -23,6 +23,7 @@ from twisted.web.client import FileBodyProducer
 from twisted.web.http_headers import Headers
 from yelp_uri import urllib_utf8
 
+from swaggerpy import client
 from swaggerpy import http_client
 from swaggerpy.exception import HTTPError
 from swaggerpy.multipart_response import create_multipart_content
@@ -62,11 +63,11 @@ class AsynchronousHttpClient(http_client.HttpClient):
         """
         eventual.cancel()
 
-    def wait(self, timeout, eventual):
+    def wait(self, eventual, timeout=None):
         """Requests based implemention with timeout
 
-        :param timeout: time in seconds to wait for response
         :param eventual: Crochet EventualResult
+        :param timeout: time in seconds to wait for response.
 
         :return: Requests response
         :rtype:  requests.Response
@@ -172,8 +173,7 @@ def stringify_body(request_params):
     elif headers.get('content-type') == http_client.APP_FORM:
         data = urllib_utf8.urlencode(request_params.get('data', {}))
     else:
-        http_client.stringify_body(request_params)
-        data = request_params.get('data')
+        data = client.stringify_body(request_params.get('data', ''))
     return FileBodyProducer(StringIO(data)) if data else None
 
 

--- a/swaggerpy/response.py
+++ b/swaggerpy/response.py
@@ -75,7 +75,7 @@ class HTTPFuture(object):
 
         if self.cancelled():
             raise CancelledError()
-        response = self._http_client.wait(timeout, self._request)
+        response = self._http_client.wait(self._request, timeout)
         try:
             response.raise_for_status()
         except Exception as e:

--- a/test-data/1.2/simple/simple.json
+++ b/test-data/1.2/simple/simple.json
@@ -1,7 +1,7 @@
 {
     "swaggerVersion": "1.2",
     "basePath": "http://localhost/swagger/test",
-    "resourcePath": "simple.{format}",
+    "resourcePath": "simple.json",
     "apis": [
         {
             "path": "/test",

--- a/test-data/1.2/simple/simple1.json
+++ b/test-data/1.2/simple/simple1.json
@@ -1,7 +1,7 @@
 {
     "swaggerVersion": "1.2",
     "basePath": "/",
-    "resourcePath": "simple.{format}",
+    "resourcePath": "simple.json",
     "apis": [
         {
             "path": "/test_http",

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -11,6 +11,14 @@ from swaggerpy.http_client import SynchronousHttpClient
 
 # noinspection PyDocstring
 class SynchronousClientTestCase(unittest.TestCase):
+
+    def _default_params(self):
+        return {
+            'method': 'GET',
+            'url': 'http://swagger.py/client-test',
+            'headers': {},
+        }
+
     @httpretty.activate
     def test_simple_get(self):
         httpretty.register_uri(
@@ -18,8 +26,11 @@ class SynchronousClientTestCase(unittest.TestCase):
             body='expected')
 
         uut = SynchronousHttpClient()
-        resp = uut.request('GET', "http://swagger.py/client-test",
-                           params={'foo': 'bar'})
+        params = self._default_params()
+        params['params'] = {'foo': 'bar'}
+
+        resp = uut.wait(uut.start_request(params))
+
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
         self.assertEqual({'foo': ['bar']},
@@ -32,8 +43,11 @@ class SynchronousClientTestCase(unittest.TestCase):
             body='expected')
 
         uut = SynchronousHttpClient()
-        resp = uut.request('GET', "http://swagger.py/client-test",
-                           params={'foo': u'酒場'})
+        params = self._default_params()
+        params['params'] = {'foo': u'酒場'}
+
+        resp = uut.wait(uut.start_request(params))
+
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
         self.assertEqual({'foo': [u'酒場']},
@@ -46,10 +60,15 @@ class SynchronousClientTestCase(unittest.TestCase):
             body='expected', content_type='text/json')
 
         uut = SynchronousHttpClient()
-        resp = uut.request('POST', "http://swagger.py/client-test",
-                           data={'foo': 'bar'})
+        params = self._default_params()
+        params['data'] = {'foo': 'bar'}
+        params['method'] = 'POST'
+
+        resp = uut.wait(uut.start_request(params))
+
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
+
         self.assertEqual('application/x-www-form-urlencoded',
                          httpretty.last_request().headers['content-type'])
         self.assertEqual("foo=bar",
@@ -63,8 +82,11 @@ class SynchronousClientTestCase(unittest.TestCase):
 
         uut = SynchronousHttpClient()
         uut.set_basic_auth("swagger.py", 'unit', 'peekaboo')
-        resp = uut.request('GET', "http://swagger.py/client-test",
-                           params={'foo': 'bar'})
+        params = self._default_params()
+        params['params'] = {'foo': 'bar'}
+
+        resp = uut.wait(uut.start_request(params))
+
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
         self.assertEqual({'foo': ['bar']},
@@ -79,10 +101,12 @@ class SynchronousClientTestCase(unittest.TestCase):
             body='expected')
 
         uut = SynchronousHttpClient()
-        uut.set_api_key("swagger.py",
-                        'abc123', param_name='test')
-        resp = uut.request('GET', "http://swagger.py/client-test",
-                           params={'foo': 'bar'})
+        uut.set_api_key("swagger.py", 'abc123', param_name='test')
+        params = self._default_params()
+        params['params'] = {'foo': 'bar'}
+
+        resp = uut.wait(uut.start_request(params))
+
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
         self.assertEqual({'foo': ['bar'], 'test': ['abc123']},
@@ -96,8 +120,12 @@ class SynchronousClientTestCase(unittest.TestCase):
 
         uut = SynchronousHttpClient()
         uut.set_basic_auth("swagger.py", 'unit', 'peekaboo')
-        resp = uut.request('GET', "http://hackerz.py",
-                           params={'foo': 'bar'})
+        params = self._default_params()
+        params['params'] = {'foo': 'bar'}
+        params['url'] = 'http://hackerz.py'
+
+        resp = uut.wait(uut.start_request(params))
+
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
         self.assertEqual({'foo': ['bar']},

--- a/tests/integration/async_http_client_test.py
+++ b/tests/integration/async_http_client_test.py
@@ -66,8 +66,8 @@ class TestServer(unittest.TestCase):
 
         eventual_one = client.start_request(request_one_params)
         eventual_two = client.start_request(request_two_params)
-        resp_one = client.wait(1, eventual_one)
-        resp_two = client.wait(1, eventual_two)
+        resp_one = client.wait(eventual_one, 1)
+        resp_two = client.wait(eventual_two, 1)
 
         self.assertEqual(resp_one.text, ROUTE_1_RESPONSE)
         self.assertEqual(resp_two.text, ROUTE_2_RESPONSE)

--- a/tests/resource_operation_test.py
+++ b/tests/resource_operation_test.py
@@ -216,6 +216,7 @@ class ResourceOperationTest(unittest.TestCase):
         with open("test-data/1.2/simple/simple.json", "rb") as f:
             resource.testHTTP(param_id=42, file_name=f).result()
             content_type = httpretty.last_request().headers['content-type']
+
             self.assertTrue(content_type.startswith('multipart/form-data'))
             self.assertTrue("42" in httpretty.last_request().body)
             # instead of asserting the contents, just assert filename is there


### PR DESCRIPTION
So, the original goal of this branch was just to use the actual client to fetch the api docs, and it now does that (though it doesn't do anything truly asynchronously). But I kind of got sidetracked. Partially fixes #73 but does not number #71.

Turns out a bunch of the tests expected HTTP bodies in GET requests, which shouldn't happen. It was also a bit awkward how we managed content types. So I killed off a lot of body awkwardness and content type awkwardness. Pretty sure this isn't a breaking change unless you're depending on a bad behavior.

Also a couple small refactors for qol.
