### PR TITLE
Rename ResponseLike to IncomingResponse (due to renaming in bravado-core)

### DIFF
--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -3,7 +3,7 @@ import logging
 
 from bravado_core.http_client import APP_FORM, HttpClient
 from bravado_core.param import stringify_body as param_stringify_body
-from bravado_core.response import ResponseLike
+from bravado_core.response import IncomingResponse
 import fido
 from yelp_uri import urllib_utf8
 
@@ -13,7 +13,7 @@ from bravado.multipart_response import create_multipart_content
 log = logging.getLogger(__name__)
 
 
-class FidoResponseAdapter(ResponseLike):
+class FidoResponseAdapter(IncomingResponse):
     """Wraps a fido.fido.Response object to provider a uniform interface
     to the response innards.
 

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -13,7 +13,7 @@ class HttpFuture(object):
         :param future: future object
         :type future: :class: `concurrent.futures.Future`
         :param response_adapter: Adapter which exposes json(), status_code()
-        :type response_adapter: :class: `bravado_core.response.ResponseLike`
+        :type response_adapter: :class: `bravado_core.response.IncomingResponse`
         :param callback: Function to be called on the response
         """
         self.future = future
@@ -46,7 +46,7 @@ def raise_http_error_based_on_status(http_response, swagger_return_value):
     compatibility. Raise an HTTPError when the http status indicates a client
     or server side error.
 
-    :param http_response: :class:`ResponseLike`
+    :param http_response: :class:`IncomingResponse`
     :param swagger_return_value: The return value of a swagger response if it
         has one, None otherwise.
     :raises: HTTPError on 4XX and 5XX http errors

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -4,7 +4,7 @@ import sys
 import urlparse
 
 from bravado_core.http_client import HttpClient
-from bravado_core.response import ResponseLike
+from bravado_core.response import IncomingResponse
 import requests
 import requests.auth
 
@@ -142,7 +142,7 @@ def add_response_detail_to_errors(e):
     raise HTTPError(*args), None, sys.exc_info()[2]
 
 
-class RequestsResponseAdapter(ResponseLike):
+class RequestsResponseAdapter(IncomingResponse):
     """Wraps a requests.models.Response object to provide a uniform interface
     to the response innards.
     """

--- a/tests/http_future/HttpFuture/result_test.py
+++ b/tests/http_future/HttpFuture/result_test.py
@@ -1,6 +1,6 @@
 from concurrent.futures import Future
 
-from bravado_core.response import ResponseLike
+from bravado_core.response import IncomingResponse
 from mock import Mock, patch
 import pytest
 
@@ -10,7 +10,7 @@ from bravado.http_future import HTTPError, HttpFuture
 def test_no_response_callback():
     # This use case is for http requests that are made outside of the
     # swagger spec e.g. retrieving the swagger schema
-    response_adapter_instance = Mock(spec=ResponseLike)
+    response_adapter_instance = Mock(spec=IncomingResponse)
     response_adapter_type = Mock(return_value=response_adapter_instance)
     http_future = HttpFuture(
         future=Mock(spec=Future),
@@ -22,7 +22,7 @@ def test_no_response_callback():
 
 def test_200_success():
     response_callback = Mock(return_value='hello world')
-    response_adapter_instance = Mock(spec=ResponseLike, status_code=200)
+    response_adapter_instance = Mock(spec=IncomingResponse, status_code=200)
     response_adapter_type = Mock(return_value=response_adapter_instance)
 
     http_future = HttpFuture(
@@ -37,7 +37,7 @@ def test_200_success():
        side_effect=HTTPError)
 def test_4XX_5XX_failure(_):
     response_callback = Mock(return_value='hello world')
-    response_adapter_instance = Mock(spec=ResponseLike, status_code=400)
+    response_adapter_instance = Mock(spec=IncomingResponse, status_code=400)
     response_adapter_type = Mock(return_value=response_adapter_instance)
 
     http_future = HttpFuture(

--- a/tests/http_future/raise_http_error_based_on_status_test.py
+++ b/tests/http_future/raise_http_error_based_on_status_test.py
@@ -1,4 +1,4 @@
-from bravado_core.response import ResponseLike
+from bravado_core.response import IncomingResponse
 from mock import Mock
 import pytest
 
@@ -6,13 +6,13 @@ from bravado.http_future import raise_http_error_based_on_status, HTTPError
 
 
 def test_200():
-    http_response = Mock(spec=ResponseLike, status_code=200)
+    http_response = Mock(spec=IncomingResponse, status_code=200)
     # no error raised == success
     raise_http_error_based_on_status(http_response, 'hello world')
 
 
 def test_http_error_raised_on_4XX_client_error():
-    http_response = Mock(spec=ResponseLike, status_code=404)
+    http_response = Mock(spec=IncomingResponse, status_code=404)
     with pytest.raises(HTTPError) as excinfo:
         raise_http_error_based_on_status(
             http_response, {'error': 'Object not found'})
@@ -20,7 +20,7 @@ def test_http_error_raised_on_4XX_client_error():
 
 
 def test_http_error_raised_on_5XX_server_error():
-    http_response = Mock(spec=ResponseLike, status_code=500)
+    http_response = Mock(spec=IncomingResponse, status_code=500)
     with pytest.raises(HTTPError) as excinfo:
         raise_http_error_based_on_status(
             http_response, {'error': 'kaboom'})


### PR DESCRIPTION
Changes required for https://github.com/Yelp/bravado-core/pull/23. Build will fail in travis until bravado-core version is bumped + released.