### PR TITLE
py3 support for bravado

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 env:
 - TOX_ENV=py26
 - TOX_ENV=py27
+- TOX_ENV=py34
 - TOX_ENV=cover
 - TOX_ENV=docs
 - TOX_ENV=flake8

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 import logging
 
+import six
+
+if six.PY3:
+    raise ImportError("The fido client is not yet supported in py3")
+
+import fido
 from bravado_core.http_client import APP_FORM, HttpClient
 from bravado_core.param import stringify_body as param_stringify_body
 from bravado_core.response import IncomingResponse
-import fido
 from yelp_uri import urllib_utf8
 
 from bravado.http_future import HttpFuture

--- a/bravado/multipart_response.py
+++ b/bravado/multipart_response.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-
 from uuid import uuid4
+
+import six
+
 from bravado_core.http_client import MULT_FORM
 
 
@@ -33,11 +35,11 @@ def create_multipart_content(request_params, headers):
     lines = []
 
     # Add all form fields
-    for k, v in request_params.get('data', {}).items():
+    for k, v in six.iteritems(request_params.get('data', {})):
         add_lines(k, v, False, boundary, lines)
 
     # Add all form files
-    for file_name, f in request_params['files'].items():
+    for file_name, f in six.iteritems(request_params['files']):
         add_lines(file_name, f.read(), True, boundary, lines)
 
     lines.extend(["--" + boundary + "--", ""])

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 import logging
 import sys
-import urlparse
 
-from bravado_core.http_client import HttpClient
-from bravado_core.response import IncomingResponse
 import requests
 import requests.auth
+import six
+from bravado_core.http_client import HttpClient
+from bravado_core.response import IncomingResponse
+from six.moves.urllib import parse as urlparse
 
 from bravado.exception import HTTPError
 from bravado.http_future import HttpFuture
@@ -107,7 +108,7 @@ class RequestsClient(HttpClient):
             requests_future,
             RequestsResponseAdapter,
             response_callback,
-            )
+        )
 
     def set_basic_auth(self, host, username, password):
         self.authenticator = BasicAuthenticator(
@@ -139,7 +140,8 @@ def add_response_detail_to_errors(e):
     args = list(e.args)
     if hasattr(e, 'response') and hasattr(e.response, 'text'):
         args[0] += (' : ' + e.response.text)
-    raise HTTPError(*args), None, sys.exc_info()[2]
+
+    raise six.reraise(HTTPError, HTTPError(*args), sys.exc_info()[2])
 
 
 class RequestsResponseAdapter(IncomingResponse):

--- a/bravado/swagger_model.py
+++ b/bravado/swagger_model.py
@@ -6,8 +6,9 @@
 import contextlib
 import logging
 import os
-import urllib
-import urlparse
+
+from six.moves import urllib
+from six.moves.urllib import parse as urlparse
 
 from bravado.compat import json
 from bravado.requests_client import RequestsClient
@@ -41,7 +42,7 @@ class FileEventual(object):
         return self.path
 
     def wait(self, timeout=None):
-        with contextlib.closing(urllib.urlopen(self.get_path())) as fp:
+        with contextlib.closing(urllib.request.urlopen(self.get_path())) as fp:
             return self.FileResponse(json.load(fp))
 
     def result(self, *args, **kwargs):
@@ -108,10 +109,10 @@ def load_file(spec_file, http_client=None):
     :raise: IOError: On error reading swagger.json.
     """
     file_path = os.path.abspath(spec_file)
-    url = urlparse.urljoin(u'file:', urllib.pathname2url(file_path))
+    url = urlparse.urljoin(u'file:', urllib.request.pathname2url(file_path))
     # When loading from files, everything is relative to the spec file
     dir_path = os.path.dirname(file_path)
-    base_url = urlparse.urljoin(u'file:', urllib.pathname2url(dir_path))
+    base_url = urlparse.urljoin(u'file:', urllib.request.pathname2url(dir_path))
     return load_url(url, http_client=http_client, base_url=base_url)
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,7 @@
 # Unit test dependencies
 bottle
-httpretty
+httpretty==0.8.6
 mock
-ordereddict
 pre-commit
 pytest
 pytest-mock

--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,13 @@ setup(
         "Programming Language :: Python :: 2.7",
     ],
     install_requires=[
-        "bravado-core >= 1.0.0-rc2",
+        "bravado-core >= 1.1.0-rc2",
         "crochet >= 1.4.0",
         "fido >= 1.0.1",
         "python-dateutil",
         "requests",
+        "six",
         "twisted >= 14.0.0",
-        "yelp_uri >= 1.0.1",
+        "yelp_uri >= 1.1.0",
     ],
 )

--- a/tests/functional/request_func_test.py
+++ b/tests/functional/request_func_test.py
@@ -1,10 +1,10 @@
 """
 Request related functional tests
 """
-import StringIO
-import urlparse
+from six.moves import cStringIO
 
 import httpretty
+from six.moves.urllib import parse as urlparse
 
 from bravado.client import SwaggerClient
 from tests.functional.conftest import register_spec, API_DOCS_URL, register_get
@@ -31,7 +31,7 @@ def test_form_params_in_request(httprettified, swagger_dict):
     content_type = httpretty.last_request().headers['content-type']
     assert 'application/x-www-form-urlencoded' == content_type
     body = urlparse.parse_qs(httpretty.last_request().body)
-    assert {'param_name': ['foo'], 'param_id': ['42']} == body
+    assert {b'param_name': [b'foo'], b'param_id': [b'42']} == body
 
 
 def test_file_upload_in_request(httprettified, swagger_dict):
@@ -52,12 +52,12 @@ def test_file_upload_in_request(httprettified, swagger_dict):
     register_spec(swagger_dict)
     httpretty.register_uri(httpretty.POST, "http://localhost/test_http?")
     resource = SwaggerClient.from_url(API_DOCS_URL).api_test
-    resource.testHTTP(param_id=42, file_name=StringIO.StringIO('boo')).result()
+    resource.testHTTP(param_id=42, file_name=cStringIO('boo')).result()
     content_type = httpretty.last_request().headers['content-type']
 
     assert content_type.startswith('multipart/form-data')
-    assert "42" in httpretty.last_request().body
-    assert "boo" in httpretty.last_request().body
+    assert b"42" in httpretty.last_request().body
+    assert b"boo" in httpretty.last_request().body
 
 
 def test_parameter_in_path_of_request(httprettified, swagger_dict):

--- a/tests/functional/response_func_test.py
+++ b/tests/functional/response_func_test.py
@@ -43,7 +43,7 @@ def test_primitive_types_returned_in_response(httprettified, swagger_dict):
         'number': 3.4,
         'boolean': True
     }
-    for rtype, rvalue in rtypes.iteritems():
+    for rtype, rvalue in rtypes.items():
         register_spec(swagger_dict, {'type': rtype})
         register_test_http(body=json.dumps(rvalue))
         assert_result(rvalue)
@@ -57,7 +57,7 @@ def test_invalid_primitive_types_in_response_raises_ValidationError(
         'number': 'foo',
         'boolean': '"NOT_BOOL"'
     }
-    for rtype, rvalue in rtypes.iteritems():
+    for rtype, rvalue in rtypes.items():
         register_spec(swagger_dict, {'type': rtype})
         register_test_http(body=json.dumps(rvalue))
         assert_raises_and_matches(ValidationError, 'is not of type')

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -71,7 +71,7 @@ class RequestsClientTestCase(unittest.TestCase):
 
         self.assertEqual('application/x-www-form-urlencoded',
                          httpretty.last_request().headers['content-type'])
-        self.assertEqual("foo=bar",
+        self.assertEqual(b"foo=bar",
                          httpretty.last_request().body)
 
     @httpretty.activate
@@ -91,8 +91,9 @@ class RequestsClientTestCase(unittest.TestCase):
         self.assertEqual('expected', resp.text)
         self.assertEqual({'foo': ['bar']},
                          httpretty.last_request().querystring)
-        self.assertEqual('Basic %s' % base64.b64encode("unit:peekaboo"),
-                         httpretty.last_request().headers.get('Authorization'))
+        self.assertEqual(
+            'Basic %s' % base64.b64encode(b"unit:peekaboo").decode('utf-8'),
+            httpretty.last_request().headers.get('Authorization'))
 
     @httpretty.activate
     def test_api_key(self):

--- a/tests/integration/fido_client_test.py
+++ b/tests/integration/fido_client_test.py
@@ -6,9 +6,13 @@ import time
 import unittest
 
 import bottle
+import pytest
+import six
 
-from bravado.fido_client import FidoClient
-
+try:
+    from bravado.fido_client import FidoClient
+except ImportError:
+    pass  # Tests will be skipped in py3
 
 ROUTE_1_RESPONSE = "HEY BUDDY"
 ROUTE_2_RESPONSE = "BYE BUDDY"
@@ -42,6 +46,7 @@ def launch_threaded_http_server(port):
     return thread
 
 
+@pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
 class TestServer(unittest.TestCase):
 
     def test_multiple_requests_against_fido_client(self):

--- a/tests/petstore/pet/addPet_test.py
+++ b/tests/petstore/pet/addPet_test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 
 def test_success(petstore):
     Pet = petstore.get_model('Pet')
@@ -11,4 +13,4 @@ def test_success(petstore):
         photoUrls=['http://fido.jpg'],
         tags=[Tag(id=102, name='friendly')])
     result = petstore.pet.addPet(body=fido).result()
-    print result
+    print(result)

--- a/tests/petstore/pet/deletePet_test.py
+++ b/tests/petstore/pet/deletePet_test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pytest
 
 
@@ -7,12 +8,12 @@ def test_200_success(petstore):
     if not pets:
         pytest.mark.xtail(reason="No pets to delete")
     pet_to_delete = pets.pop()
-    print pet_to_delete.id
+    print(pet_to_delete.id)
     result = petstore.pet.deletePet(petId=pet_to_delete.id).result()
-    print result
+    print(result)
 
 
 @pytest.mark.xfail(reason="Don't know how to induce a 400")
 def test_400_invalid_pet_value(petstore):
     result = petstore.pet.deletePet(petId=999).result()
-    print result
+    print(result)

--- a/tests/petstore/pet/getPetById_test.py
+++ b/tests/petstore/pet/getPetById_test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from pprint import pprint
 import pytest
 
@@ -6,7 +7,7 @@ def test_200_success(petstore):
     pet_api = petstore.pet
     future = pet_api.getPetById(petId=1)
     pet = future.result()
-    print type(pet)
+    print(type(pet))
     pprint(pet)
     assert type(pet).__name__ == 'Pet'
     assert pet.name

--- a/tests/petstore/pet/updatePetWithForm_test.py
+++ b/tests/petstore/pet/updatePetWithForm_test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pytest
 
 
@@ -6,7 +7,7 @@ def test_success(petstore):
         petId='1',
         name='darwin',
         status='available').result()
-    print result
+    print(result)
     assert result
 
 

--- a/tests/petstore/pet/uploadFile_test.py
+++ b/tests/petstore/pet/uploadFile_test.py
@@ -1,10 +1,12 @@
+from __future__ import print_function
+
 
 def test_success(petstore):
     contents = "this is supposed to be a file"
-    print len(contents)
+    print(len(contents))
     status, result = petstore.pet.uploadFile(
         petId=1,
         file=contents,
         additionalMetadata="testing file upload").result()
-    print status
-    print result
+    print(status)
+    print(result)

--- a/tests/petstore/store/getInventory_test.py
+++ b/tests/petstore/store/getInventory_test.py
@@ -1,6 +1,8 @@
+from __future__ import print_function
+
 
 def test_success(petstore):
     inventory = petstore.store.getInventory().result()
     assert dict == type(inventory)
     assert inventory
-    print inventory
+    print(inventory)

--- a/tests/petstore/store/getOrderById_test.py
+++ b/tests/petstore/store/getOrderById_test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pytest
 
 
@@ -9,10 +10,10 @@ def test_200_success(petstore):
 @pytest.mark.xfail(reason='Currently returning a 500 instead of a 404')
 def test_404_order_not_found(petstore):
     order = petstore.store.getOrderById(orderId='7').result()
-    print order
+    print(order)
 
 
 @pytest.mark.xfail(reason='Currently returning a 500 instead of a 404')
 def test_400_invalid_id_supplied(petstore):
     order = petstore.store.getOrderById(orderId='@').result()
-    print order
+    print(order)

--- a/tests/petstore/user/deleteUser_test.py
+++ b/tests/petstore/user/deleteUser_test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pytest
 
 
@@ -9,10 +10,10 @@ def test_200_success(petstore):
 @pytest.mark.xfail(reason="Can't get this to 404")
 def test_404_user_not_found(petstore):
     result = petstore.user.deleteUser(username='zzz').result()
-    print result
+    print(result)
 
 
 @pytest.mark.xfail(reason="Can't get this to 400")
 def test_400_invalid_username(petstore):
     result = petstore.user.deleteUser(username='aaa').result()
-    print result
+    print(result)

--- a/tests/petstore/user/loginUser_test.py
+++ b/tests/petstore/user/loginUser_test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pytest
 
 
@@ -5,7 +6,7 @@ import pytest
 def test_200_success(petstore):
     result = petstore.user.loginUser(
         username='bozo', password='letmein').result()
-    print result
+    print(result)
 
     # operation says that is produces:
     #

--- a/tests/petstore/user/updateUser_test.py
+++ b/tests/petstore/user/updateUser_test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pytest
 
 
@@ -32,7 +33,7 @@ def test_404_user_not_found(petstore):
     )
     result = petstore.user.updateUser(
         username='i_dont_exist', body=user).result()
-    print result
+    print(result)
 
 
 @pytest.mark.xfail(reason='Broken on server side - blindly succeeds')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, flake8
+envlist = py26, py27, py34, flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
Should be all we need for py34.

The downside is it's not yet possible to use fido with py3 (twisted doesn't fully support it yet). So, the fido client raises an import error when you try to use it in py3.

I'm going to try to figure out a suitable async client in the meantime for py3 (though probably would make it a separate package or something of that nature)