### PR TITLE
Pass responses appropriately to errors

### DIFF
--- a/swaggerpy/response.py
+++ b/swaggerpy/response.py
@@ -26,9 +26,13 @@ def handle_response_errors(e):
     :raises HTTPError: :class: `swaggerpy.exception.HTTPError`
     """
     args = list(e.args)
+    kwargs = {}
     if hasattr(e, 'response') and hasattr(e.response, 'text'):
         args[0] += (' : ' + e.response.text)
-    raise HTTPError(*args), None, sys.exc_info()[2]
+        kwargs['response'] = e.response
+    if hasattr(e, 'request'):
+        kwargs['request'] = e.request
+    raise HTTPError(*args, **kwargs), None, sys.exc_info()[2]
 
 
 class HTTPFuture(object):

--- a/tests/resource_response_test.py
+++ b/tests/resource_response_test.py
@@ -55,16 +55,17 @@ is validated against its type 'Pet' which is defined like so:
 """
 
 import datetime
-from swaggerpy.compat import json
 import unittest
-from mock import Mock
+from swaggerpy.compat import json
 
 import httpretty
 from dateutil.tz import tzutc
+from mock import Mock
 
 from swaggerpy.client import SwaggerClient
 from swaggerpy.exception import CancelledError, HTTPError
 from swaggerpy.processors import SwaggerError
+from swaggerpy.response import handle_response_errors
 from swaggerpy.response import HTTPFuture
 
 
@@ -85,6 +86,22 @@ class HTTPFutureTest(unittest.TestCase):
 
     def test_cancelled_returns_false_if_called_before_cancel(self):
         self.assertFalse(self.future.cancelled())
+
+
+class HandleResponseErrorsTest(unittest.TestCase):
+
+    def test_pass_response_and_request(self):
+        request = Mock()
+        response = Mock(text='{"foo": "bar"}')
+        error = Mock(
+            args=('400 Bad Request',), response=response, request=request
+        )
+        try:
+            handle_response_errors(error)
+        except HTTPError as e:
+            self.assertEqual(e.json, {'foo': 'bar'})
+            self.assertEqual(e.response, response)
+            self.assertEqual(e.request, request)
 
 
 class ResourceResponseTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #156 , the main issue being that we actually weren't passing responses to exceptions properly.

e.json might make a good convenience method, but I skipped it for now (e.response.json() is a fine substitute. But documenting this at some point would be good)