### PR TITLE
Pass responses appropriately to errors (swaggerpy)

### DIFF
--- a/swaggerpy/response.py
+++ b/swaggerpy/response.py
@@ -26,9 +26,17 @@ def handle_response_errors(e):
     :raises HTTPError: :class: `swaggerpy.exception.HTTPError`
     """
     args = list(e.args)
-    if hasattr(e, 'response') and hasattr(e.response, 'text'):
-        args[0] += (' : ' + e.response.text)
-    raise HTTPError(*args), None, sys.exc_info()[2]
+    kwargs = {}
+
+    if hasattr(e, 'response'):
+        kwargs['response'] = e.response
+        if hasattr(e.response, 'text'):
+            args[0] += (' : ' + e.response.text)
+
+    if hasattr(e, 'request'):
+        kwargs['request'] = e.request
+
+    raise HTTPError(*args, **kwargs), None, sys.exc_info()[2]
 
 
 class HTTPFuture(object):


### PR DESCRIPTION
Fixes #156 , the main issue being that we actually weren't passing responses to exceptions properly.

e.json might make a good convenience method, but I skipped it for now (e.response.json is a good substitute. But documenting this at some point would be good)