### PR TITLE
Support timeouts in _request_options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+2.2.0 (2015-XX-XX)
+---------------------
+- Support passing in connect_timeout and timeout via _request_options to the Fido and Requests clients
+
 2.1.0 (2015-07-20)
 ---------------------
 - Add warning for deprecated operations

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
-2.2.0 (2015-XX-XX)
+3.0.0 (2015-XX-XX)
 ---------------------
 - Support passing in connect_timeout and timeout via _request_options to the Fido and Requests clients
+- Timeout in HTTPFuture now defaults to None (wait indefinitely) instead of 5s. You should make sure
+  any calls to http_future.result(..) without a timeout are updated accordingly.
 
 2.1.0 (2015-07-20)
 ---------------------

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -67,7 +67,7 @@ class FidoClient(HttpClient):
 
         for fetch_kwarg in ('connect_timeout', 'timeout'):
             if fetch_kwarg in request_params:
-                fetch_kwargs[fetch_kwargs] = request_params[fetch_kwarg]
+                fetch_kwargs[fetch_kwarg] = request_params[fetch_kwarg]
 
         concurrent_future = fido.fetch(url, **fetch_kwargs)
 

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -59,13 +59,19 @@ class FidoClient(HttpClient):
         url = '%s?%s' % (request_params['url'], urllib_utf8.urlencode(
             request_params.get('params', []), True))
 
-        request_params = {
+        fetch_kwargs = {
             'method': str(request_params.get('method', 'GET')),
             'body': stringify_body(request_params),
             'headers': request_params.get('headers', {}),
         }
 
-        return HttpFuture(fido.fetch(url, **request_params),
+        for fetch_kwarg in ('connect_timeout', 'timeout'):
+            if fetch_kwarg in request_params:
+                fetch_kwargs[fetch_kwargs] = request_params[fetch_kwarg]
+
+        concurrent_future = fido.fetch(url, **fetch_kwargs)
+
+        return HttpFuture(concurrent_future,
                           FidoResponseAdapter,
                           response_callback)
 

--- a/bravado/http_client.py
+++ b/bravado/http_client.py
@@ -9,7 +9,8 @@ class HttpClient(object):
 
     def request(self, request_params, response_callback=None):
         """
-        :param request_params: complete request data.
+        :param request_params: complete request data. e.g. url, method,
+            headers, body, params, connect_timeout, timeout, etc.
         :type request_params: dict
         :param response_callback: Function to be called on response
         :type response_callback: method

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from bravado.exception import HTTPError
 
-DEFAULT_TIMEOUT_S = 5.0
-
 
 class HttpFuture(object):
     """A future which inputs HTTP params"""
@@ -20,11 +18,12 @@ class HttpFuture(object):
         self.response_adapter = response_adapter
         self.response_callback = callback
 
-    def result(self, timeout=DEFAULT_TIMEOUT_S):
+    def result(self, timeout=None):
         """Blocking call to wait for API response
 
-        :param timeout: Timeout in seconds for which client will get blocked
-        to receive the response
+        :param timeout: Number of seconds to wait for a response. Defaults to
+            None which means wait indefinitely.
+        :type timeout: float
         :return: swagger response return value when given a callback or the
             http_response otherwise.
         """

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -107,16 +107,16 @@ class RequestsClient(HttpClient):
         :returns: tuple(sanitized_params, misc_options)
         """
         sanitized_params = request_params.copy()
-        request_options = {}
+        misc_options = {}
 
         if 'connect_timeout' in sanitized_params:
-            request_options['connect_timeout'] = \
+            misc_options['connect_timeout'] = \
                 sanitized_params.pop('connect_timeout')
 
         if 'timeout' in sanitized_params:
-            request_options['timeout'] = sanitized_params.pop('timeout')
+            misc_options['timeout'] = sanitized_params.pop('timeout')
 
-        return sanitized_params, request_options
+        return sanitized_params, misc_options
 
     def request(self, request_params, response_callback=None):
         """

--- a/tests/fido_client/FidoClient/request_test.py
+++ b/tests/fido_client/FidoClient/request_test.py
@@ -1,0 +1,31 @@
+from mock import patch, call
+from bravado.fido_client import FidoClient
+
+
+@patch('bravado.fido_client.fido.fetch')
+def test_timeout_passed_to_fido(fetch):
+    fido_client = FidoClient()
+    request_params = dict(url='http://foo.com/', timeout=1)
+    fido_client.request(request_params, response_callback=None)
+    assert fetch.call_args == call(
+        'http://foo.com/?', body='', headers={}, method='GET', timeout=1)
+
+
+@patch('bravado.fido_client.fido.fetch')
+def test_connect_timeout_passed_to_fido(fetch):
+    fido_client = FidoClient()
+    request_params = dict(url='http://foo.com/', connect_timeout=1)
+    fido_client.request(request_params, response_callback=None)
+    assert fetch.call_args == call(
+        'http://foo.com/?', body='', headers={}, method='GET',
+        connect_timeout=1)
+
+
+@patch('bravado.fido_client.fido.fetch')
+def test_connect_timeout_and_timeout_passed_to_fido(fetch):
+    fido_client = FidoClient()
+    request_params = dict(url='http://foo.com/', connect_timeout=1, timeout=2)
+    fido_client.request(request_params, response_callback=None)
+    assert fetch.call_args == call(
+        'http://foo.com/?', body='', headers={}, method='GET',
+        connect_timeout=1, timeout=2)

--- a/tests/fido_client/FidoClient/request_test.py
+++ b/tests/fido_client/FidoClient/request_test.py
@@ -10,7 +10,7 @@ except ImportError:
 
 
 @pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
-def test_no_timeouts_passed_to_fido(fetch):
+def test_no_timeouts_passed_to_fido():
     with patch('bravado.fido_client.fido.fetch') as fetch:
         fido_client = FidoClient()
         request_params = dict(url='http://foo.com/')
@@ -20,7 +20,7 @@ def test_no_timeouts_passed_to_fido(fetch):
 
 
 @pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
-def test_timeout_passed_to_fido(fetch):
+def test_timeout_passed_to_fido():
     with patch('bravado.fido_client.fido.fetch') as fetch:
         fido_client = FidoClient()
         request_params = dict(url='http://foo.com/', timeout=1)
@@ -30,7 +30,7 @@ def test_timeout_passed_to_fido(fetch):
 
 
 @pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
-def test_connect_timeout_passed_to_fido(fetch):
+def test_connect_timeout_passed_to_fido():
     with patch('bravado.fido_client.fido.fetch') as fetch:
         fido_client = FidoClient()
         request_params = dict(url='http://foo.com/', connect_timeout=1)
@@ -41,7 +41,7 @@ def test_connect_timeout_passed_to_fido(fetch):
 
 
 @pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
-def test_connect_timeout_and_timeout_passed_to_fido(fetch):
+def test_connect_timeout_and_timeout_passed_to_fido():
     with patch('bravado.fido_client.fido.fetch') as fetch:
         fido_client = FidoClient()
         request_params = dict(url='http://foo.com/', connect_timeout=1,

--- a/tests/fido_client/FidoClient/request_test.py
+++ b/tests/fido_client/FidoClient/request_test.py
@@ -3,6 +3,15 @@ from bravado.fido_client import FidoClient
 
 
 @patch('bravado.fido_client.fido.fetch')
+def test_no_timeouts_passed_to_fido(fetch):
+    fido_client = FidoClient()
+    request_params = dict(url='http://foo.com/')
+    fido_client.request(request_params, response_callback=None)
+    assert fetch.call_args == call(
+        'http://foo.com/?', body='', headers={}, method='GET')
+
+
+@patch('bravado.fido_client.fido.fetch')
 def test_timeout_passed_to_fido(fetch):
     fido_client = FidoClient()
     request_params = dict(url='http://foo.com/', timeout=1)

--- a/tests/fido_client/FidoClient/request_test.py
+++ b/tests/fido_client/FidoClient/request_test.py
@@ -1,40 +1,52 @@
-from mock import patch, call
-from bravado.fido_client import FidoClient
+from mock import patch, call, Mock
+import pytest
+import six
 
 
-@patch('bravado.fido_client.fido.fetch')
+try:
+    from bravado.fido_client import FidoClient
+except ImportError:
+    FidoClient = Mock()
+
+
+@pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
 def test_no_timeouts_passed_to_fido(fetch):
-    fido_client = FidoClient()
-    request_params = dict(url='http://foo.com/')
-    fido_client.request(request_params, response_callback=None)
-    assert fetch.call_args == call(
-        'http://foo.com/?', body='', headers={}, method='GET')
+    with patch('bravado.fido_client.fido.fetch') as fetch:
+        fido_client = FidoClient()
+        request_params = dict(url='http://foo.com/')
+        fido_client.request(request_params, response_callback=None)
+        assert fetch.call_args == call(
+            'http://foo.com/?', body='', headers={}, method='GET')
 
 
-@patch('bravado.fido_client.fido.fetch')
+@pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
 def test_timeout_passed_to_fido(fetch):
-    fido_client = FidoClient()
-    request_params = dict(url='http://foo.com/', timeout=1)
-    fido_client.request(request_params, response_callback=None)
-    assert fetch.call_args == call(
-        'http://foo.com/?', body='', headers={}, method='GET', timeout=1)
+    with patch('bravado.fido_client.fido.fetch') as fetch:
+        fido_client = FidoClient()
+        request_params = dict(url='http://foo.com/', timeout=1)
+        fido_client.request(request_params, response_callback=None)
+        assert fetch.call_args == call(
+            'http://foo.com/?', body='', headers={}, method='GET', timeout=1)
 
 
-@patch('bravado.fido_client.fido.fetch')
+@pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
 def test_connect_timeout_passed_to_fido(fetch):
-    fido_client = FidoClient()
-    request_params = dict(url='http://foo.com/', connect_timeout=1)
-    fido_client.request(request_params, response_callback=None)
-    assert fetch.call_args == call(
-        'http://foo.com/?', body='', headers={}, method='GET',
-        connect_timeout=1)
+    with patch('bravado.fido_client.fido.fetch') as fetch:
+        fido_client = FidoClient()
+        request_params = dict(url='http://foo.com/', connect_timeout=1)
+        fido_client.request(request_params, response_callback=None)
+        assert fetch.call_args == call(
+            'http://foo.com/?', body='', headers={}, method='GET',
+            connect_timeout=1)
 
 
-@patch('bravado.fido_client.fido.fetch')
+@pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
 def test_connect_timeout_and_timeout_passed_to_fido(fetch):
-    fido_client = FidoClient()
-    request_params = dict(url='http://foo.com/', connect_timeout=1, timeout=2)
-    fido_client.request(request_params, response_callback=None)
-    assert fetch.call_args == call(
-        'http://foo.com/?', body='', headers={}, method='GET',
-        connect_timeout=1, timeout=2)
+    with patch('bravado.fido_client.fido.fetch') as fetch:
+        fido_client = FidoClient()
+        request_params = dict(url='http://foo.com/', connect_timeout=1,
+                              timeout=2)
+        fido_client.request(request_params, response_callback=None)
+        assert fetch.call_args == call(
+            'http://foo.com/?', body='', headers={}, method='GET',
+            connect_timeout=1, timeout=2)

--- a/tests/requests_client/RequestsClient/separate_params_test.py
+++ b/tests/requests_client/RequestsClient/separate_params_test.py
@@ -1,0 +1,12 @@
+from bravado.requests_client import RequestsClient
+
+
+def test_separate_params():
+    request_params = {
+        'url': 'http://foo.com',
+        'connect_timeout': 1,
+        'timeout': 2
+    }
+    sanitized, misc = RequestsClient.separate_params(request_params)
+    assert sanitized == {'url': 'http://foo.com'}
+    assert misc == {'connect_timeout': 1, 'timeout': 2}

--- a/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
+++ b/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
@@ -1,0 +1,57 @@
+from mock import Mock
+import pytest
+from requests.sessions import Session
+
+from bravado.requests_client import RequestsFutureAdapter
+
+
+@pytest.fixture
+def request():
+    return dict(url='http://foo.com')
+
+
+@pytest.fixture
+def session():
+    return Mock(spec=Session)
+
+
+def test_no_timeouts(session, request):
+    misc_options = {}
+    future = RequestsFutureAdapter(session, request, misc_options)
+    assert future.build_timeout(result_timeout=None) is None
+
+
+def test_service_timeout_and_no_result_timeout(session, request):
+    misc_options = dict(timeout=1)
+    future = RequestsFutureAdapter(session, request, misc_options)
+    assert future.build_timeout(result_timeout=None) == 1
+
+
+def test_no_service_timeout_and_result_timeout(session, request):
+    misc_options = {}
+    future = RequestsFutureAdapter(session, request, misc_options)
+    assert future.build_timeout(result_timeout=1) == 1
+
+
+def test_service_timeout_lt_result_timeout(session, request):
+    misc_options = dict(timeout=10)
+    future = RequestsFutureAdapter(session, request, misc_options)
+    assert future.build_timeout(result_timeout=11) == 11
+
+
+def test_service_timeout_gt_result_timeout(session, request):
+    misc_options = dict(timeout=11)
+    future = RequestsFutureAdapter(session, request, misc_options)
+    assert future.build_timeout(result_timeout=10) == 11
+
+
+def test_connect_timeout_and_idle_timeout(session, request):
+    misc_options = dict(connect_timeout=1, timeout=11)
+    future = RequestsFutureAdapter(session, request, misc_options)
+    assert future.build_timeout(result_timeout=None) == (1, 11)
+
+
+def test_connect_timeout_only(session, request):
+    misc_options = dict(connect_timeout=1)
+    future = RequestsFutureAdapter(session, request, misc_options)
+    assert future.build_timeout(result_timeout=None) == (1, None)

--- a/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
+++ b/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
@@ -21,13 +21,13 @@ def test_no_timeouts(session, request):
     assert future.build_timeout(result_timeout=None) is None
 
 
-def test_service_timeout_and_no_result_timeout(session, request):
+def test_service_timeout_and_result_timeout_None(session, request):
     misc_options = dict(timeout=1)
     future = RequestsFutureAdapter(session, request, misc_options)
     assert future.build_timeout(result_timeout=None) == 1
 
 
-def test_no_service_timeout_and_result_timeout(session, request):
+def test_no_service_timeout_and_result_timeout_not_None(session, request):
     misc_options = {}
     future = RequestsFutureAdapter(session, request, misc_options)
     assert future.build_timeout(result_timeout=1) == 1
@@ -55,6 +55,12 @@ def test_service_timeout_not_None_result_timeout_None(session, request):
     misc_options = dict(timeout=10)
     future = RequestsFutureAdapter(session, request, misc_options)
     assert future.build_timeout(result_timeout=None) == 10
+
+
+def test_both_timeouts_the_same(session, request):
+    misc_options = dict(timeout=10)
+    future = RequestsFutureAdapter(session, request, misc_options)
+    assert future.build_timeout(result_timeout=10) == 10
 
 
 def test_connect_timeout_and_idle_timeout(session, request):

--- a/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
+++ b/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
@@ -45,6 +45,18 @@ def test_service_timeout_gt_result_timeout(session, request):
     assert future.build_timeout(result_timeout=10) == 11
 
 
+def test_service_timeout_None_result_timeout_not_None(session, request):
+    misc_options = dict(timeout=None)
+    future = RequestsFutureAdapter(session, request, misc_options)
+    assert future.build_timeout(result_timeout=10) == 10
+
+
+def test_service_timeout_not_None_result_timeout_None(session, request):
+    misc_options = dict(timeout=10)
+    future = RequestsFutureAdapter(session, request, misc_options)
+    assert future.build_timeout(result_timeout=None) == 10
+
+
 def test_connect_timeout_and_idle_timeout(session, request):
     misc_options = dict(connect_timeout=1, timeout=11)
     future = RequestsFutureAdapter(session, request, misc_options)


### PR DESCRIPTION
So `_request_options` currently only supports `headers`. This adds support for `timeout` and `connect_timeout` to both the Fido and Requests http clients.

Fixes issue #165 