### PR TITLE
Make the return type of HttpFuture.result() configurable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+6.1.0 (2015-XX-XX)
+------------------
+- Clients can now access the HTTP response from a service call to access things
+  like headers and status code. See `Advanced Usage <http://http://bravado.readthedocs.org/en/latest/advanced.html#getting-access-to-the-http-response>`_
+
 6.0.0 (2015-10-12)
 ------------------
 - User-defined formats are no longer global. The registration mechanism has

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 6.1.0 (2015-XX-XX)
 ------------------
 - Clients can now access the HTTP response from a service call to access things
-  like headers and status code. See `Advanced Usage <http://http://bravado.readthedocs.org/en/latest/advanced.html#getting-access-to-the-http-response>`_
+  like headers and status code. See `Advanced Usage <http://bravado.readthedocs.org/en/latest/advanced.html#getting-access-to-the-http-response>`_
 
 6.0.0 (2015-10-12)
 ------------------

--- a/bravado/client.py
+++ b/bravado/client.py
@@ -69,7 +69,7 @@ log = logging.getLogger(__name__)
 CONFIG_DEFAULTS = {
     # See the constructor of :class:`bravado.http_future.HttpFuture` for an
     # in depth explanation of what this means.
-    'return_swagger_result': True
+    'also_return_response': False
 }
 
 
@@ -255,12 +255,12 @@ class CallableOperation(object):
         warn_for_deprecated_op(self.operation)
         request_params = self.construct_request(**op_kwargs)
         callback = functools.partial(response_callback, operation=self)
-        return_swagger_result = \
-            self.operation.swagger_spec.config['return_swagger_result']
+        also_return_response = \
+            self.operation.swagger_spec.config['also_return_response']
         return self.operation.swagger_spec.http_client.request(
             request_params,
             callback,
-            return_swagger_result=return_swagger_result)
+            also_return_response)
 
 
 def response_callback(incoming_response, operation):

--- a/bravado/client.py
+++ b/bravado/client.py
@@ -66,21 +66,25 @@ from bravado.warning import warn_for_deprecated_op
 log = logging.getLogger(__name__)
 
 
+CONFIG_DEFAULTS = {
+    # See the constructor of :class:`bravado.http_future.HttpFuture` for an
+    # in depth explanation of what this means.
+    'return_swagger_result': True
+}
+
+
 class SwaggerClient(object):
     """A client for accessing a Swagger-documented RESTful service.
-    """
 
+    :param swagger_spec: :class:`bravado_core.spec.Spec`
+    """
     def __init__(self, swagger_spec):
-        """
-        :param swagger_spec: :class:`bravado_core.spec.Spec`
-        """
         self.swagger_spec = swagger_spec
 
     @classmethod
     def from_url(cls, spec_url, http_client=None, request_headers=None,
                  config=None):
-        """
-        Build a :class:`SwaggerClient` from a url to the Swagger
+        """Build a :class:`SwaggerClient` from a url to the Swagger
         specification for a RESTful API.
 
         :param spec_url: url pointing at the swagger API specification
@@ -89,11 +93,10 @@ class SwaggerClient(object):
         :type  http_client: :class:`bravado.http_client.HttpClient`
         :param request_headers: Headers to pass with http requests
         :type  request_headers: dict
-        :param config: bravado_core config dict. See
-            bravado_core.spec.CONFIG_DEFAULTS
+        :param config: Config dict for bravado and bravado_core.
+            See CONFIG_DEFAULTS in :module:`bravado_core.spec`.
+            See CONFIG_DEFAULTS in :module:`bravado.client`.
         """
-        # TODO: better way to customize the request for api calls, so we don't
-        #       have to add new kwargs for everything
         log.debug(u"Loading from %s" % spec_url)
         http_client = http_client or RequestsClient()
         loader = Loader(http_client, request_headers=request_headers)
@@ -104,7 +107,7 @@ class SwaggerClient(object):
     def from_spec(cls, spec_dict, origin_url=None, http_client=None,
                   config=None):
         """
-        Build a :class:`SwaggerClient` from swagger api docs
+        Build a :class:`SwaggerClient` from a Swagger spec in dict form.
 
         :param spec_dict: a dict with a Swagger spec in json-like form
         :param origin_url: the url used to retrieve the spec_dict
@@ -112,6 +115,10 @@ class SwaggerClient(object):
         :param config: Configuration dict - see spec.CONFIG_DEFAULTS
         """
         http_client = http_client or RequestsClient()
+
+        # Apply bravado config defaults
+        config = dict(CONFIG_DEFAULTS, **(config or {}))
+
         swagger_spec = Spec.from_dict(
             spec_dict, origin_url, http_client, config)
         return cls(swagger_spec)
@@ -248,19 +255,23 @@ class CallableOperation(object):
         warn_for_deprecated_op(self.operation)
         request_params = self.construct_request(**op_kwargs)
         callback = functools.partial(response_callback, operation=self)
-        return self.operation.swagger_spec.http_client.request(request_params,
-                                                               callback)
+        return_swagger_result = \
+            self.operation.swagger_spec.config['return_swagger_result']
+        return self.operation.swagger_spec.http_client.request(
+            request_params,
+            callback,
+            return_swagger_result=return_swagger_result)
 
 
 def response_callback(incoming_response, operation):
     """
     So the http_client is finished with its part of processing the response.
     This hands the response over to bravado_core for validation and
-    unmarshalling.
+    unmarshalling. On success, the swagger_result is available as
+    `incoming_response.swagger_result`.
 
     :type incoming_response: :class:`bravado_core.response.IncomingResponse`
     :type operation: :class:`bravado_core.operation.Operation`
-    :return: Response spec's return value.
     :raises: HTTPError
         - On 5XX status code, the HTTPError has minimal information.
         - On non-2XX status code with no matching response, the HTTPError
@@ -271,15 +282,16 @@ def response_callback(incoming_response, operation):
     raise_on_unexpected(incoming_response)
 
     try:
-        swagger_return_value = unmarshal_response(incoming_response, operation)
+        incoming_response.swagger_result = unmarshal_response(
+            incoming_response,
+            operation)
     except MatchingResponseNotFound as e:
         six.reraise(
             HTTPError,
             HTTPError(response=incoming_response, message=str(e)),
             sys.exc_info()[2])
 
-    raise_on_expected(incoming_response, swagger_return_value)
-    return swagger_return_value
+    raise_on_expected(incoming_response)
 
 
 def raise_on_unexpected(http_response):
@@ -293,17 +305,15 @@ def raise_on_unexpected(http_response):
         raise HTTPError(response=http_response)
 
 
-def raise_on_expected(http_response, swagger_return_value):
+def raise_on_expected(http_response):
     """
     Raise an HTTPError if the response is non-2XX and matches a response in the
     swagger spec.
 
     :param http_response: :class:`bravado_core.response.IncomingResponse`
-    :param swagger_return_value: The return value of a swagger response if it
-        has one, None otherwise.
     :raises: HTTPError
     """
     if not 200 <= http_response.status_code < 300:
         raise HTTPError(
             response=http_response,
-            swagger_result=swagger_return_value)
+            swagger_result=http_response.swagger_result)

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -49,7 +49,7 @@ class FidoClient(HttpClient):
     """
 
     def request(self, request_params, response_callback=None,
-                return_swagger_result=True):
+                also_return_response=False):
         """Sets up the request params as per Twisted Agent needs.
         Sets up crochet and triggers the API request in background
 
@@ -58,7 +58,7 @@ class FidoClient(HttpClient):
         :param response_callback: Function to be called after
         receiving the response
         :type response_callback: method
-        :param return_swagger_result: Consult the constructor documentation for
+        :param also_return_response: Consult the constructor documentation for
             :class:`bravado.http_future.HttpFuture`.
 
         :rtype: :class: `bravado_core.http_future.HttpFuture`
@@ -81,7 +81,7 @@ class FidoClient(HttpClient):
         return HttpFuture(concurrent_future,
                           FidoResponseAdapter,
                           response_callback,
-                          return_swagger_result)
+                          also_return_response)
 
 
 def stringify_body(request_params):

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -48,7 +48,8 @@ class FidoClient(HttpClient):
     """Fido (Asynchronous) HTTP client implementation.
     """
 
-    def request(self, request_params, response_callback=None):
+    def request(self, request_params, response_callback=None,
+                return_swagger_result=True):
         """Sets up the request params as per Twisted Agent needs.
         Sets up crochet and triggers the API request in background
 
@@ -57,6 +58,8 @@ class FidoClient(HttpClient):
         :param response_callback: Function to be called after
         receiving the response
         :type response_callback: method
+        :param return_swagger_result: Consult the constructor documentation for
+            :class:`bravado.http_future.HttpFuture`.
 
         :rtype: :class: `bravado_core.http_future.HttpFuture`
         """
@@ -77,7 +80,8 @@ class FidoClient(HttpClient):
 
         return HttpFuture(concurrent_future,
                           FidoResponseAdapter,
-                          response_callback)
+                          response_callback,
+                          return_swagger_result)
 
 
 def stringify_body(request_params):

--- a/bravado/http_client.py
+++ b/bravado/http_client.py
@@ -7,14 +7,14 @@ class HttpClient(object):
     """Interface for a minimal HTTP client.
     """
     def request(self, request_params, response_callback=None,
-                return_swagger_result=True):
+                also_return_response=False):
         """
         :param request_params: complete request data. e.g. url, method,
             headers, body, params, connect_timeout, timeout, etc.
         :type request_params: dict
         :param response_callback: Function to be called on response
         :type response_callback: method
-        :param return_swagger_result: Consult the constructor documentation for
+        :param also_return_response: Consult the constructor documentation for
             :class:`bravado.http_future.HttpFuture`.
 
         :returns: HTTP Future object

--- a/bravado/http_client.py
+++ b/bravado/http_client.py
@@ -6,14 +6,16 @@ MULT_FORM = 'multipart/form-data'
 class HttpClient(object):
     """Interface for a minimal HTTP client.
     """
-
-    def request(self, request_params, response_callback=None):
+    def request(self, request_params, response_callback=None,
+                return_swagger_result=True):
         """
         :param request_params: complete request data. e.g. url, method,
             headers, body, params, connect_timeout, timeout, etc.
         :type request_params: dict
         :param response_callback: Function to be called on response
         :type response_callback: method
+        :param return_swagger_result: Consult the constructor documentation for
+            :class:`bravado.http_future.HttpFuture`.
 
         :returns: HTTP Future object
         :rtype: :class: `bravado_core.http_future.HttpFuture`

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -14,19 +14,22 @@ class HttpFuture(object):
         :class:`bravado_core.response.IncomingResponse`.
     :param callback: Function to be called on the response (usually for
         bravado-core post-processing).
-    :param return_swagger_result: returns the Swagger result
-        when True or the HTTP response object when False. This is useful
-        if you want access to additional data from the HTTP response other than
-        just the Swagger result. e.g. http headers, http response code, etc.
-        Defaults to true mostly for backwards compatibility and simplicity at
-        the Swagger client's call site.
+    :param also_return_response: Determines if the incoming http response is
+        included as part of the return value from calling
+        `HttpFuture.result()`.
+        When False, only the swagger result is returned.
+        When True, the tuple(swagger result, http response) is returned.
+        This is useful if you want access to additional data that is not
+        accessible from the swagger result. e.g. http headers,
+        http response code, etc.
+        Defaults to False for backwards compatibility.
     """
     def __init__(self, future, response_adapter, callback,
-                 return_swagger_result=True):
+                 also_return_response=False):
         self.future = future
         self.response_adapter = response_adapter
         self.response_callback = callback
-        self.return_swagger_result = return_swagger_result
+        self.also_return_response = also_return_response
 
     def result(self, timeout=None):
         """Blocking call to wait for the HTTP response.
@@ -34,7 +37,7 @@ class HttpFuture(object):
         :param timeout: Number of seconds to wait for a response. Defaults to
             None which means wait indefinitely.
         :type timeout: float
-        :return: Depends on the value of return_swagger_result sent in
+        :return: Depends on the value of also_return_response sent in
             to the constructor.
         """
         inner_response = self.future.result(timeout=timeout)
@@ -42,9 +45,10 @@ class HttpFuture(object):
 
         if self.response_callback:
             self.response_callback(incoming_response)
-            if self.return_swagger_result:
-                return incoming_response.swagger_result
-            return incoming_response
+            swagger_result = incoming_response.swagger_result
+            if self.also_return_response:
+                return swagger_result, incoming_response
+            return swagger_result
 
         if 200 <= incoming_response.status_code < 300:
             return incoming_response

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -3,36 +3,48 @@ from bravado.exception import HTTPError
 
 
 class HttpFuture(object):
-    """A future which inputs HTTP params"""
+    """Wrapper for a :class:`concurrent.futures.Future` that returns an HTTP
+    response.
 
-    def __init__(self, future, response_adapter, callback):
-        """Kicks API call for Fido client
-
-        :param future: future object
-        :type future: :class: `concurrent.futures.Future`
-        :param response_adapter: Adapter which exposes json(), status_code()
-        :type response_adapter: :class: `bravado_core.response.IncomingResponse`
-        :param callback: Function to be called on the response
-        """
+    :param future: The concurrent future to wrap.
+    :type future: :class: `concurrent.futures.Future`
+    :param response_adapter: Adapter type which exposes the innards of the HTTP
+        response in a non-http client specific way.
+    :type response_adapter: type that is a subclass of
+        :class:`bravado_core.response.IncomingResponse`.
+    :param callback: Function to be called on the response (usually for
+        bravado-core post-processing).
+    :param return_swagger_result: returns the Swagger result
+        when True or the HTTP response object when False. This is useful
+        if you want access to additional data from the HTTP response other than
+        just the Swagger result. e.g. http headers, http response code, etc.
+        Defaults to true mostly for backwards compatibility and simplicity at
+        the Swagger client's call site.
+    """
+    def __init__(self, future, response_adapter, callback,
+                 return_swagger_result=True):
         self.future = future
         self.response_adapter = response_adapter
         self.response_callback = callback
+        self.return_swagger_result = return_swagger_result
 
     def result(self, timeout=None):
-        """Blocking call to wait for API response
+        """Blocking call to wait for the HTTP response.
 
         :param timeout: Number of seconds to wait for a response. Defaults to
             None which means wait indefinitely.
         :type timeout: float
-        :return: swagger response return value when given a callback or the
-            http_response otherwise.
+        :return: Depends on the value of return_swagger_result sent in
+            to the constructor.
         """
         inner_response = self.future.result(timeout=timeout)
         incoming_response = self.response_adapter(inner_response)
 
         if self.response_callback:
-            swagger_return_value = self.response_callback(incoming_response)
-            return swagger_return_value
+            self.response_callback(incoming_response)
+            if self.return_swagger_result:
+                return incoming_response.swagger_result
+            return incoming_response
 
         if 200 <= incoming_response.status_code < 300:
             return incoming_response

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -116,12 +116,12 @@ class RequestsClient(HttpClient):
         return sanitized_params, misc_options
 
     def request(self, request_params, response_callback=None,
-                return_swagger_result=True):
+                also_return_response=False):
         """
         :param request_params: complete request data.
         :type request_params: dict
         :param response_callback: Function to be called on the response
-        :param return_swagger_result: Consult the constructor documentation for
+        :param also_return_response: Consult the constructor documentation for
             :class:`bravado.http_future.HttpFuture`.
 
         :returns: HTTP Future object
@@ -138,7 +138,7 @@ class RequestsClient(HttpClient):
             requests_future,
             RequestsResponseAdapter,
             response_callback,
-            return_swagger_result
+            also_return_response
         )
 
     def set_basic_auth(self, host, username, password):

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -115,11 +115,15 @@ class RequestsClient(HttpClient):
 
         return sanitized_params, misc_options
 
-    def request(self, request_params, response_callback=None):
+    def request(self, request_params, response_callback=None,
+                return_swagger_result=True):
         """
         :param request_params: complete request data.
         :type request_params: dict
         :param response_callback: Function to be called on the response
+        :param return_swagger_result: Consult the constructor documentation for
+            :class:`bravado.http_future.HttpFuture`.
+
         :returns: HTTP Future object
         :rtype: :class: `bravado_core.http_future.HttpFuture`
         """
@@ -134,6 +138,7 @@ class RequestsClient(HttpClient):
             requests_future,
             RequestsResponseAdapter,
             response_callback,
+            return_swagger_result
         )
 
     def set_basic_auth(self, host, username, password):

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -10,20 +10,20 @@ Validation example:
 
 .. code-block:: python
 
-        pet = Pet(id="I should be integer :(", name="tommy")
-        client.pet.addPet(body=pet).result()
+    pet = Pet(id="I should be integer :(", name="tommy")
+    client.pet.addPet(body=pet).result()
 
 will result in an error like so:
 
 .. code-block:: console
 
-        TypeError: id's value: 'I should be integer :(' should be in types (<type 'long'>, <type 'int'>)
+    TypeError: id's value: 'I should be integer :(' should be in types (<type 'long'>, <type 'int'>)
 
 .. note::
 
-       If you'd like to disable validation of outgoing requests, you can set ``validate_requests`` to ``False`` in the ``config`` passed to ``SwaggerClient.from_url(...)``.
+   If you'd like to disable validation of outgoing requests, you can set ``validate_requests`` to ``False`` in the ``config`` passed to ``SwaggerClient.from_url(...)``.
 
-       The same holds true for incoming responses with the ``validate_responses`` config option.
+   The same holds true for incoming responses with the ``validate_responses`` config option.
 
 Adding Request Headers
 ----------------------
@@ -32,13 +32,13 @@ Adding Request Headers
 
 .. code-block:: python
 
-        Pet = client.get_model('Pet')
-        Category = client.get_model('Category')
-        pet = Pet(id=42, name="tommy", category=Category(id=24))
-        swagger_client.pet.addPet(
-            body=pet,
-            _request_options={"headers": {"foo": "bar"}},
-        ).result()
+    Pet = client.get_model('Pet')
+    Category = client.get_model('Category')
+    pet = Pet(id=42, name="tommy", category=Category(id=24))
+    swagger_client.pet.addPet(
+        body=pet,
+        _request_options={"headers": {"foo": "bar"}},
+    ).result()
 
 
 Docstrings
@@ -51,56 +51,56 @@ in the ``Docstring`` section.
 
 .. note::
 
-        The ``help`` built-in does not work as expected for docstrings. Use the ``?`` method instead.
+    The ``help`` built-in does not work as expected for docstrings. Use the ``?`` method instead.
 
 .. code-block:: console
 
-        >> petstore.pet.getPetById?
+    >> petstore.pet.getPetById?
 
-        Type:       CallableOperation
-        String Form:<bravado.client.CallableOperation object at 0x241b5d0>
-        File:       /some/dir/bravado/bravado/client.py
-        Definition: c.pet.getPetById(self, **op_kwargs)
-        Docstring:
-        [GET] Find pet by ID
+    Type:       CallableOperation
+    String Form:<bravado.client.CallableOperation object at 0x241b5d0>
+    File:       /some/dir/bravado/bravado/client.py
+    Definition: c.pet.getPetById(self, **op_kwargs)
+    Docstring:
+    [GET] Find pet by ID
 
-        Returns a single pet
+    Returns a single pet
 
-        :param petId: ID of pet to return
-        :type petId: integer
-        :returns: 200: successful operation
-        :rtype: object
-        :returns: 400: Invalid ID supplied
-        :returns: 404: Pet not found
-        Constructor Docstring::type operation: :class:`bravado_core.operation.Operation`
-        Call def:   c.pet.getPetById(self, **op_kwargs)
-        Call docstring:
-        Invoke the actual HTTP request and return a future that encapsulates
-        the HTTP response.
+    :param petId: ID of pet to return
+    :type petId: integer
+    :returns: 200: successful operation
+    :rtype: object
+    :returns: 400: Invalid ID supplied
+    :returns: 404: Pet not found
+    Constructor Docstring::type operation: :class:`bravado_core.operation.Operation`
+    Call def:   c.pet.getPetById(self, **op_kwargs)
+    Call docstring:
+    Invoke the actual HTTP request and return a future that encapsulates
+    the HTTP response.
 
-        :rtype: :class:`bravado.http_future.HTTPFuture`
+    :rtype: :class:`bravado.http_future.HTTPFuture`
 
 Docstrings for models can be retrieved as expected:
 
 .. code-block:: console
 
-        >> pet_model = petstore.get_model('Pet')
-        >> pet_model?
+    >> pet_model = petstore.get_model('Pet')
+    >> pet_model?
 
-        Type:       type
-        String Form:<class 'bravado_core.model.Pet'>
-        File:       /some/dir/bravado_core/model.py
-        Docstring:
-        Attributes:
+    Type:       type
+    String Form:<class 'bravado_core.model.Pet'>
+    File:       /some/dir/bravado_core/model.py
+    Docstring:
+    Attributes:
 
-        category: Category
-        id: integer
-        name: string
-        photoUrls: list of string
-        status: string - pet status in the store
-        tags: list of Tag
-        Constructor information:
-         Definition:pet_type(self, **kwargs)
+    category: Category
+    id: integer
+    name: string
+    photoUrls: list of string
+    status: string - pet status in the store
+    tags: list of Tag
+    Constructor information:
+     Definition:pet_type(self, **kwargs)
 
 Default Values
 --------------
@@ -111,7 +111,7 @@ In the `Pet Store <http://petstore.swagger.io/>`_ example, operation ``findPetsB
 
 .. code-block:: python
 
-        client.pet.findPetByStatus()
+    client.pet.findPetByStatus()
 
 Loading swagger.json by file path
 ---------------------------------
@@ -120,12 +120,39 @@ Loading swagger.json by file path
 
 .. code-block:: python
 
-        client = SwaggerClient.from_url('file:///some/path/swagger.json')
+    client = SwaggerClient.from_url('file:///some/path/swagger.json')
 
 Alternatively, you can also use the ``load_file`` helper method.
 
 .. code-block:: python
 
-        from bravado.swagger_model import load_file
+    from bravado.swagger_model import load_file
 
-        client = SwaggerClient.from_dict(load_file('/path/to/swagger.json'))
+    client = SwaggerClient.from_dict(load_file('/path/to/swagger.json'))
+
+.. _getting_access_to_the_http_response:
+
+Getting access to the HTTP response
+-----------------------------------
+
+The default behavior for a service call is to return the swagger result like so:
+
+.. code-block:: python
+
+    pet = petstore.pet.getPetById(petId=42).result()
+    print pet.name
+
+However, there are times when it is necessary to have access to the actual
+HTTP response so that the HTTP headers or HTTP status code can be used. This
+is easily done via configuration to return a
+``(swagger result, http response)`` tuple from the service call.
+
+.. code-block:: python
+
+    petstore = Swagger.from_url(..., config={'also_return_response': True})
+    pet, http_response = petstore.pet.getPetById(petId=42).result()
+    assert isinstance(http_response, bravado_core.response.IncomingResponse)
+    print http_response.headers
+    print http_response.status_code
+    print pet.name
+

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -3,7 +3,9 @@ Configuration
 
 You can configure certain behaviours when creating a ``SwaggerClient``.
 
-The full documentation for each config key is in `bravado-core <http://bravado-core.readthedocs.org/en/latest/config.html>`_.
+bravado and bravado-core use the same config dict. The full documentation for
+`bravado-core config keys <http://bravado-core.readthedocs.org/en/latest/config.html>`_
+is available too.
 
 .. code-block:: python
 
@@ -12,6 +14,13 @@ The full documentation for each config key is in `bravado-core <http://bravado-c
     my_super_duper_format = SwaggerFormat(...)
 
     config = {
+        # === bravado config ===
+
+        # Determines what is returned by the service call.
+        'also_return_response': False,
+
+        # === bravado-core config ====
+
         #  validate incoming responses
         'validate_responses': True,
 
@@ -19,13 +28,26 @@ The full documentation for each config key is in `bravado-core <http://bravado-c
         'validate_requests': True,
 
         # validate the swagger spec
-        'validate_swagger_spec': True
+        'validate_swagger_spec': True,
 
         # Use models (Python classes) instead of dicts for #/definitions/{models}
-        'use_models': True
+        'use_models': True,
 
         # List of user-defined formats
-        'formats': [my_super_duper_format]
+        'formats': [my_super_duper_format],
+
     }
 
     client = SwaggerClient.from_url(..., config=config)
+
+
+========================= =============== =========  ===============================================================
+Config key                Type            Default    Description
+------------------------- --------------- ---------  ---------------------------------------------------------------
+*also_return_response*    boolean         False      | Determines what is returned by the service call.
+                                                     | Specifically, the return value of ``HttpFuture.result()``.
+                                                     | When ``False``, the swagger result is returned.
+                                                     | When ``True``, the tuple ``(swagger result, http response)``
+                                                     | is returned.
+                                                     | See :ref:`getting_access_to_the_http_response`.
+========================= =============== =========  ===============================================================

--- a/tests/client/raise_on_expected_test.py
+++ b/tests/client/raise_on_expected_test.py
@@ -7,16 +7,21 @@ from bravado.exception import HTTPError
 
 
 def test_2XX():
-    http_response = Mock(spec=IncomingResponse, status_code=200)
-    swagger_return_value = {'msg': 'Request successful'}
-    # no error raised == success
-    raise_on_expected(http_response, swagger_return_value)
+    http_response = Mock(
+        spec=IncomingResponse,
+        status_code=200,
+        swagger_result='hello world')
+
+    # no exception raised == success
+    raise_on_expected(http_response)
 
 
 def test_non_2XX():
-    http_response = Mock(spec=IncomingResponse, status_code=404)
+    http_response = Mock(
+        spec=IncomingResponse,
+        status_code=404,
+        swagger_result={'error': 'Object not found'})
+
     with pytest.raises(HTTPError) as excinfo:
-        raise_on_expected(
-            http_response,
-            swagger_return_value={'error': 'Object not found'})
+        raise_on_expected(http_response)
     assert 'Object not found' in str(excinfo.value)

--- a/tests/client/response_callback_test.py
+++ b/tests/client/response_callback_test.py
@@ -21,8 +21,8 @@ def test_2XX(_1):
     incoming_response = Mock(spec=IncomingResponse)
     incoming_response.status_code = 200
     operation = Mock(spec=Operation)
-    swagger_result = response_callback(incoming_response, operation)
-    assert swagger_result == 99
+    response_callback(incoming_response, operation)
+    assert incoming_response.swagger_result == 99
 
 
 @patch('bravado.client.unmarshal_response',

--- a/tests/http_future/HttpFuture/result_test.py
+++ b/tests/http_future/HttpFuture/result_test.py
@@ -67,7 +67,7 @@ def test_non_2XX_with_response_callback():
     assert excinfo.value.response.status_code == 400
 
 
-def test_return_response_true():
+def test_also_return_response_true():
     # Verify HTTPFuture(..., also_return_response=True).result()
     # returns the (swagger_result, http_response) and not just swagger_result
     def response_callback(incoming_response):

--- a/tests/http_future/HttpFuture/result_test.py
+++ b/tests/http_future/HttpFuture/result_test.py
@@ -67,9 +67,9 @@ def test_non_2XX_with_response_callback():
     assert excinfo.value.response.status_code == 400
 
 
-def test_return_swagger_result_false():
-    # Verify HTTPFuture(..., return_swagger_result=False).result()
-    # returns the http response and not the swagger_result
+def test_return_response_true():
+    # Verify HTTPFuture(..., also_return_response=True).result()
+    # returns the (swagger_result, http_response) and not just swagger_result
     def response_callback(incoming_response):
         incoming_response.swagger_result = 'hello world'
 
@@ -80,9 +80,9 @@ def test_return_swagger_result_false():
         future=Mock(spec=Future),
         response_adapter=response_adapter_type,
         callback=response_callback,
-        return_swagger_result=False)
+        also_return_response=True)
 
-    http_response = http_future.result()
+    swagger_result, http_response = http_future.result()
 
     assert http_response == response_adapter_instance
-    assert http_response.swagger_result == 'hello world'
+    assert swagger_result == 'hello world'

--- a/tests/http_future/HttpFuture/result_test.py
+++ b/tests/http_future/HttpFuture/result_test.py
@@ -34,8 +34,14 @@ def test_non_2XX_no_response_callback():
 
 
 def test_200_with_response_callback():
-    response_callback = Mock(return_value='hello world')
-    response_adapter_instance = Mock(spec=IncomingResponse, status_code=200)
+
+    def response_callback(incoming_response):
+        incoming_response.swagger_result = 'hello world'
+
+    response_adapter_instance = Mock(
+        spec=IncomingResponse,
+        status_code=200)
+
     response_adapter_type = Mock(return_value=response_adapter_instance)
 
     http_future = HttpFuture(
@@ -59,3 +65,24 @@ def test_non_2XX_with_response_callback():
     with pytest.raises(HTTPError) as excinfo:
         http_future.result()
     assert excinfo.value.response.status_code == 400
+
+
+def test_return_swagger_result_false():
+    # Verify HTTPFuture(..., return_swagger_result=False).result()
+    # returns the http response and not the swagger_result
+    def response_callback(incoming_response):
+        incoming_response.swagger_result = 'hello world'
+
+    response_adapter_instance = Mock(spec=IncomingResponse, status_code=200)
+    response_adapter_type = Mock(return_value=response_adapter_instance)
+
+    http_future = HttpFuture(
+        future=Mock(spec=Future),
+        response_adapter=response_adapter_type,
+        callback=response_callback,
+        return_swagger_result=False)
+
+    http_response = http_future.result()
+
+    assert http_response == response_adapter_instance
+    assert http_response.swagger_result == 'hello world'


### PR DESCRIPTION
See #173 for context.

- Defaults to the current behavior to maintain backwards compatibility. 
- I will update the sphinx docs on how to use this feature in detail once the implementation is reviewed.

Configure to return an http response:
```python
client = SwaggerClient(..., config={'return_swagger_result':False})
http_response = client.pet.getPetById(petId=42).result()
assert isinstance(response, bravado_core.response.IncomingResponse)
pet = http_response.swagger_result
assert http_response.status_code == 200
```

Configure to return the swagger result (default):
```python
client = SwaggerClient(..., config={'return_swagger_result':True})
pet = client.pet.getPetById(petId=42).result()
assert pet.name
```
