### PR TITLE
Expose http headers in IncomingResponse subclasses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+6.1.1 (2015-XX-XX)
+------------------
+- Fix ``IncomingResponse`` subclasses to provide access to the http headers.
+- Requires bravado-core >= 3.1.0
+
 6.1.0 (2015-10-19)
 ------------------
 - Clients can now access the HTTP response from a service call to access things

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 class FidoResponseAdapter(IncomingResponse):
-    """Wraps a fido.fido.Response object to provider a uniform interface
+    """Wraps a fido.fido.Response object to provide a uniform interface
     to the response innards.
 
     :type fido_response: :class:`fido.fido.Response`
@@ -38,6 +38,10 @@ class FidoResponseAdapter(IncomingResponse):
     @property
     def reason(self):
         return self._delegate.reason
+
+    @property
+    def headers(self):
+        return self._delegate.headers
 
     def json(self, **_):
         # TODO: pass the kwargs downstream

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -182,6 +182,10 @@ class RequestsResponseAdapter(IncomingResponse):
     def reason(self):
         return self._delegate.reason
 
+    @property
+    def headers(self):
+        return self._delegate.headers
+
     def json(self, **kwargs):
         return self._delegate.json(**kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "Programming Language :: Python :: 3.4",
     ],
     install_requires=[
-        "bravado-core >= 3.0.2",
+        "bravado-core >= 3.1.0",
         "crochet >= 1.4.0",
         "fido >= 2.1.0",
         "python-dateutil",


### PR DESCRIPTION
Fixes the bug introduced in 6.1.0.