### PR TITLE
Require twisted < 15.5.0 since Python 2.6 support was dropped

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+0.7.11 (2015-XX-XX)
+------------------
+- Require twisted < 15.5.0 since Python 2.6 support was dropped.
+
 0.7.10 (2015-07-07)
 ------------------
 - Make request and response available as attrs on HTTPError

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "crochet >= 1.4.0",
         "python-dateutil",
         "requests",
-        "twisted >= 14.0.0",
+        "twisted >= 14.0.0, < 15.5.0", # Twisted dropped Python 2.6 support in 15.5.0
         "yelp_uri >= 1.0.1",
     ],
 )


### PR DESCRIPTION
Latest twisted dropped python 2.6 support.