### PR TITLE
Support dot in operation name

### DIFF
--- a/bravado/client.py
+++ b/bravado/client.py
@@ -218,17 +218,11 @@ class ResourceDecorator(object):
         """
         Exposes correct attrs on resource when tab completing in a REPL
         """
-        dir_list = []
-
         if not self.base_name == '':
             # If there is a base_name, get all the element starting by base_name
-            for value in self.resource.__dir__():
-                if value.startswith(self.base_name):
-                    dir_list.append(value.replace(self.base_name, ''))
+            return [i for i in self.resource.__dir__() if i.startswith(self.base_name)]
         else:
             return self.resource.__dir__()
-
-        return dir_list
 
 
 class CallableOperation(object):

--- a/test-data/2.0/petstore/swagger.json
+++ b/test-data/2.0/petstore/swagger.json
@@ -88,7 +88,7 @@
         ],
         "summary": "Update an existing pet",
         "description": "",
-        "operationId": "updatePet",
+        "operationId": "test.updatePet",
         "consumes": [
           "application/json",
           "application/xml"

--- a/tests/client/ResourceDecorator/dir_test.py
+++ b/tests/client/ResourceDecorator/dir_test.py
@@ -1,4 +1,4 @@
 def test_forwarded_to_delegate(petstore_client):
     expected = ['addPet', 'deletePet', 'findPetsByStatus', 'findPetsByTags',
-                'getPetById', 'updatePet', 'updatePetWithForm', 'uploadFile']
+                'getPetById', 'test.updatePet', 'updatePetWithForm', 'uploadFile']
     assert expected == dir(petstore_client.pet)

--- a/tests/client/SwaggerClient/getattr_test.py
+++ b/tests/client/SwaggerClient/getattr_test.py
@@ -1,13 +1,19 @@
 import pytest
 
+from bravado.client import CallableOperation
 from bravado.client import ResourceDecorator
 
 
 def test_resource_exists(petstore_client):
     assert type(petstore_client.pet) == ResourceDecorator
+    assert type(petstore_client.pet.test) == ResourceDecorator
+    assert type(petstore_client.pet.test.updatePet) == CallableOperation
 
 
 def test_resource_not_found(petstore_client):
     with pytest.raises(AttributeError) as excinfo:
         petstore_client.foo
     assert 'foo not found' in str(excinfo.value)
+
+    with pytest.raises(AttributeError) as excinfo:
+        petstore_client.pet.test.error


### PR DESCRIPTION
This pull request allow dot in an operation name. OperationID can have dot, especially if you use [connexion](https://github.com/zalando/connexion).