### PR TITLE
Add support for parsing YAML specs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,11 @@
 Changelog
 =========
 
-8.0.2 (2016-XX-XX)
+8.1.0 (2016-XX-XX)
 ------------------
+- Support for YAML Swagger specs
 - Remove pytest-mock dependency from requirements-dev.txt. No longer used and it was breaking the build.
+- Requires bravado-core >= 4.1.0
 
 8.0.1 (2015-12-02)
 ------------------

--- a/bravado/__init__.py
+++ b/bravado/__init__.py
@@ -1,1 +1,1 @@
-version = '8.0.1'
+version = '8.1.0'

--- a/bravado/swagger_model.py
+++ b/bravado/swagger_model.py
@@ -119,7 +119,10 @@ class Loader(object):
             for method, operation in iter(methods.items()):
                 if 'responses' in operation:
                     operation['responses'] = dict(
-                        (str(code), response) for code, response in iter(operation['responses'].items())
+                        (str(code), response)
+                        for code, response in iter(
+                            operation['responses'].items()
+                        )
                     )
 
         return data

--- a/bravado/swagger_model.py
+++ b/bravado/swagger_model.py
@@ -31,7 +31,7 @@ class FileEventual(object):
             self.headers = {}
 
         def json(self):
-            return self.text
+            return json.loads(self.text)
 
     def __init__(self, path):
         self.path = path
@@ -44,7 +44,7 @@ class FileEventual(object):
 
     def wait(self, timeout=None):
         with contextlib.closing(urllib.request.urlopen(self.get_path())) as fp:
-            content = fp.read() if self.is_yaml else json.load(fp)
+            content = fp.read()
             return self.FileResponse(content)
 
     def result(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,11 @@ setup(
         "Programming Language :: Python :: 3.4",
     ],
     install_requires=[
-        "bravado-core >= 4.0.0",
+        "bravado-core >= 4.1.0",
         "crochet >= 1.4.0",
         "fido >= 2.1.0",
         "python-dateutil",
+        "pyyaml",
         "requests",
         "six",
         "twisted >= 14.0.0, < 15.5.0", # Python 2.6 support was dropped in 15.5.0

--- a/test-data/2.0/petstore/swagger.json
+++ b/test-data/2.0/petstore/swagger.json
@@ -72,15 +72,7 @@
           "405": {
             "description": "Invalid input"
           }
-        },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -118,15 +110,7 @@
           "405": {
             "description": "Validation exception"
           }
-        },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ]
+        }
       }
     },
     "/pet/findByStatus": {
@@ -135,7 +119,7 @@
           "pet"
         ],
         "summary": "Finds Pets by status",
-        "description": "Multiple status values can be provided with comma seperated strings",
+        "description": "Multiple status values can be provided with comma separated strings",
         "operationId": "findPetsByStatus",
         "produces": [
           "application/xml",
@@ -157,7 +141,7 @@
               ],
               "default": "available"
             },
-            "collectionFormat": "csv"
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -173,15 +157,7 @@
           "400": {
             "description": "Invalid status value"
           }
-        },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ]
+        }
       }
     },
     "/pet/findByTags": {
@@ -190,7 +166,7 @@
           "pet"
         ],
         "summary": "Finds Pets by tags",
-        "description": "Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.",
+        "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
         "operationId": "findPetsByTags",
         "produces": [
           "application/xml",
@@ -206,7 +182,7 @@
             "items": {
               "type": "string"
             },
-            "collectionFormat": "csv"
+            "collectionFormat": "multi"
           }
         ],
         "responses": {
@@ -223,14 +199,7 @@
             "description": "Invalid tag value"
           }
         },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ]
+        "deprecated": true
       }
     },
     "/pet/{petId}": {
@@ -317,15 +286,7 @@
           "405": {
             "description": "Invalid input"
           }
-        },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -356,17 +317,12 @@
         ],
         "responses": {
           "400": {
-            "description": "Invalid pet value"
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
           }
-        },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ]
+        }
       }
     },
     "/pet/{petId}/uploadImage": {
@@ -414,15 +370,7 @@
               "$ref": "#/definitions/ApiResponse"
             }
           }
-        },
-        "security": [
-          {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
-          }
-        ]
+        }
       }
     },
     "/store/inventory": {
@@ -498,7 +446,7 @@
           "store"
         ],
         "summary": "Find purchase order by ID",
-        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions",
+        "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
         "operationId": "getOrderById",
         "produces": [
           "application/xml",
@@ -511,7 +459,7 @@
             "description": "ID of pet that needs to be fetched",
             "required": true,
             "type": "integer",
-            "maximum": 5,
+            "maximum": 10,
             "minimum": 1,
             "format": "int64"
           }
@@ -536,7 +484,7 @@
           "store"
         ],
         "summary": "Delete purchase order by ID",
-        "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+        "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
         "operationId": "deleteOrder",
         "produces": [
           "application/xml",
@@ -548,8 +496,9 @@
             "in": "path",
             "description": "ID of the order that needs to be deleted",
             "required": true,
-            "type": "string",
-            "minimum": 1
+            "type": "integer",
+            "minimum": 1,
+            "format": "int64"
           }
         ],
         "responses": {
@@ -701,7 +650,7 @@
               "X-Expires-After": {
                 "type": "string",
                 "format": "date-time",
-                "description": "date in UTC when toekn expires"
+                "description": "date in UTC when token expires"
               }
             }
           },
@@ -782,7 +731,7 @@
           {
             "name": "username",
             "in": "path",
-            "description": "name that need to be deleted",
+            "description": "name that need to be updated",
             "required": true,
             "type": "string"
           },
@@ -837,15 +786,6 @@
     }
   },
   "securityDefinitions": {
-    "petstore_auth": {
-      "type": "oauth2",
-      "authorizationUrl": "http://petstore.swagger.io/api/oauth/dialog",
-      "flow": "implicit",
-      "scopes": {
-        "write:pets": "modify pets in your account",
-        "read:pets": "read your pets"
-      }
-    },
     "api_key": {
       "type": "apiKey",
       "name": "api_key",
@@ -955,6 +895,21 @@
         "name": "Tag"
       }
     },
+    "ApiResponse": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "type": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
     "Pet": {
       "type": "object",
       "required": [
@@ -1005,21 +960,6 @@
       },
       "xml": {
         "name": "Pet"
-      }
-    },
-    "ApiResponse": {
-      "type": "object",
-      "properties": {
-        "code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "type": {
-          "type": "string"
-        },
-        "message": {
-          "type": "string"
-        }
       }
     }
   },

--- a/test-data/2.0/petstore/swagger.yaml
+++ b/test-data/2.0/petstore/swagger.yaml
@@ -1,0 +1,671 @@
+---
+swagger: "2.0"
+info:
+  description: "This is a sample server Petstore server.  You can find out more about\
+    \ Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).\
+    \  For this sample, you can use the api key `special-key` to test the authorization\
+    \ filters."
+  version: "1.0.0"
+  title: "Swagger Petstore"
+  termsOfService: "http://swagger.io/terms/"
+  contact:
+    email: "apiteam@swagger.io"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+host: "petstore.swagger.io"
+basePath: "/v2"
+tags:
+- name: "pet"
+  description: "Everything about your Pets"
+  externalDocs:
+    description: "Find out more"
+    url: "http://swagger.io"
+- name: "store"
+  description: "Access to Petstore orders"
+- name: "user"
+  description: "Operations about user"
+  externalDocs:
+    description: "Find out more about our store"
+    url: "http://swagger.io"
+schemes:
+- "http"
+paths:
+  /pet:
+    post:
+      tags:
+      - "pet"
+      summary: "Add a new pet to the store"
+      description: ""
+      operationId: "addPet"
+      consumes:
+      - "application/json"
+      - "application/xml"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Pet object that needs to be added to the store"
+        required: true
+        schema:
+          $ref: "#/definitions/Pet"
+      responses:
+        405:
+          description: "Invalid input"
+    put:
+      tags:
+      - "pet"
+      summary: "Update an existing pet"
+      description: ""
+      operationId: "updatePet"
+      consumes:
+      - "application/json"
+      - "application/xml"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Pet object that needs to be added to the store"
+        required: true
+        schema:
+          $ref: "#/definitions/Pet"
+      responses:
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+        405:
+          description: "Validation exception"
+  /pet/findByStatus:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by status"
+      description: "Multiple status values can be provided with comma separated strings"
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "status"
+        in: "query"
+        description: "Status values that need to be considered for filter"
+        required: true
+        type: "array"
+        items:
+          type: "string"
+          enum:
+          - "available"
+          - "pending"
+          - "sold"
+          default: "available"
+        collectionFormat: "multi"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid status value"
+  /pet/findByTags:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by tags"
+      description: "Muliple tags can be provided with comma separated strings. Use\
+        \ tag1, tag2, tag3 for testing."
+      operationId: "findPetsByTags"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "tags"
+        in: "query"
+        description: "Tags to filter by"
+        required: true
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid tag value"
+      deprecated: true
+  /pet/{petId}:
+    get:
+      tags:
+      - "pet"
+      summary: "Find pet by ID"
+      description: "Returns a single pet"
+      operationId: "getPetById"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "petId"
+        in: "path"
+        description: "ID of pet to return"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+      security:
+      - api_key: []
+    post:
+      tags:
+      - "pet"
+      summary: "Updates a pet in the store with form data"
+      description: ""
+      operationId: "updatePetWithForm"
+      consumes:
+      - "application/x-www-form-urlencoded"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "petId"
+        in: "path"
+        description: "ID of pet that needs to be updated"
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "name"
+        in: "formData"
+        description: "Updated name of the pet"
+        required: false
+        type: "string"
+      - name: "status"
+        in: "formData"
+        description: "Updated status of the pet"
+        required: false
+        type: "string"
+      responses:
+        405:
+          description: "Invalid input"
+    delete:
+      tags:
+      - "pet"
+      summary: "Deletes a pet"
+      description: ""
+      operationId: "deletePet"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "api_key"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "petId"
+        in: "path"
+        description: "Pet id to delete"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+  /pet/{petId}/uploadImage:
+    post:
+      tags:
+      - "pet"
+      summary: "uploads an image"
+      description: ""
+      operationId: "uploadFile"
+      consumes:
+      - "multipart/form-data"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "petId"
+        in: "path"
+        description: "ID of pet to update"
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "additionalMetadata"
+        in: "formData"
+        description: "Additional data to pass to server"
+        required: false
+        type: "string"
+      - name: "file"
+        in: "formData"
+        description: "file to upload"
+        required: false
+        type: "file"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ApiResponse"
+  /store/inventory:
+    get:
+      tags:
+      - "store"
+      summary: "Returns pet inventories by status"
+      description: "Returns a map of status codes to quantities"
+      operationId: "getInventory"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "integer"
+              format: "int32"
+      security:
+      - api_key: []
+  /store/order:
+    post:
+      tags:
+      - "store"
+      summary: "Place an order for a pet"
+      description: ""
+      operationId: "placeOrder"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "order placed for purchasing the pet"
+        required: true
+        schema:
+          $ref: "#/definitions/Order"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Order"
+        400:
+          description: "Invalid Order"
+  /store/order/{orderId}:
+    get:
+      tags:
+      - "store"
+      summary: "Find purchase order by ID"
+      description: "For valid response try integer IDs with value >= 1 and <= 10.\
+        \ Other values will generated exceptions"
+      operationId: "getOrderById"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "orderId"
+        in: "path"
+        description: "ID of pet that needs to be fetched"
+        required: true
+        type: "integer"
+        maximum: 10.0
+        minimum: 1.0
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Order"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Order not found"
+    delete:
+      tags:
+      - "store"
+      summary: "Delete purchase order by ID"
+      description: "For valid response try integer IDs with positive integer value.\
+        \ Negative or non-integer values will generate API errors"
+      operationId: "deleteOrder"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "orderId"
+        in: "path"
+        description: "ID of the order that needs to be deleted"
+        required: true
+        type: "integer"
+        minimum: 1.0
+        format: "int64"
+      responses:
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Order not found"
+  /user:
+    post:
+      tags:
+      - "user"
+      summary: "Create user"
+      description: "This can only be done by the logged in user."
+      operationId: "createUser"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Created user object"
+        required: true
+        schema:
+          $ref: "#/definitions/User"
+      responses:
+        default:
+          description: "successful operation"
+  /user/createWithArray:
+    post:
+      tags:
+      - "user"
+      summary: "Creates list of users with given input array"
+      description: ""
+      operationId: "createUsersWithArrayInput"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "List of user object"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/User"
+      responses:
+        default:
+          description: "successful operation"
+  /user/createWithList:
+    post:
+      tags:
+      - "user"
+      summary: "Creates list of users with given input array"
+      description: ""
+      operationId: "createUsersWithListInput"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "List of user object"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/User"
+      responses:
+        default:
+          description: "successful operation"
+  /user/login:
+    get:
+      tags:
+      - "user"
+      summary: "Logs user into the system"
+      description: ""
+      operationId: "loginUser"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "username"
+        in: "query"
+        description: "The user name for login"
+        required: true
+        type: "string"
+      - name: "password"
+        in: "query"
+        description: "The password for login in clear text"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+          headers:
+            X-Rate-Limit:
+              type: "integer"
+              format: "int32"
+              description: "calls per hour allowed by the user"
+            X-Expires-After:
+              type: "string"
+              format: "date-time"
+              description: "date in UTC when token expires"
+        400:
+          description: "Invalid username/password supplied"
+  /user/logout:
+    get:
+      tags:
+      - "user"
+      summary: "Logs out current logged in user session"
+      description: ""
+      operationId: "logoutUser"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters: []
+      responses:
+        default:
+          description: "successful operation"
+  /user/{username}:
+    get:
+      tags:
+      - "user"
+      summary: "Get user by user name"
+      description: ""
+      operationId: "getUserByName"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "username"
+        in: "path"
+        description: "The name that needs to be fetched. Use user1 for testing. "
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/User"
+        400:
+          description: "Invalid username supplied"
+        404:
+          description: "User not found"
+    put:
+      tags:
+      - "user"
+      summary: "Updated user"
+      description: "This can only be done by the logged in user."
+      operationId: "updateUser"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "username"
+        in: "path"
+        description: "name that need to be updated"
+        required: true
+        type: "string"
+      - in: "body"
+        name: "body"
+        description: "Updated user object"
+        required: true
+        schema:
+          $ref: "#/definitions/User"
+      responses:
+        400:
+          description: "Invalid user supplied"
+        404:
+          description: "User not found"
+    delete:
+      tags:
+      - "user"
+      summary: "Delete user"
+      description: "This can only be done by the logged in user."
+      operationId: "deleteUser"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "username"
+        in: "path"
+        description: "The name that needs to be deleted"
+        required: true
+        type: "string"
+      responses:
+        400:
+          description: "Invalid username supplied"
+        404:
+          description: "User not found"
+securityDefinitions:
+  api_key:
+    type: "apiKey"
+    name: "api_key"
+    in: "header"
+definitions:
+  Order:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      petId:
+        type: "integer"
+        format: "int64"
+      quantity:
+        type: "integer"
+        format: "int32"
+      shipDate:
+        type: "string"
+        format: "date-time"
+      status:
+        type: "string"
+        description: "Order Status"
+        enum:
+        - "placed"
+        - "approved"
+        - "delivered"
+      complete:
+        type: "boolean"
+        default: false
+    xml:
+      name: "Order"
+  User:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      username:
+        type: "string"
+      firstName:
+        type: "string"
+      lastName:
+        type: "string"
+      email:
+        type: "string"
+      password:
+        type: "string"
+      phone:
+        type: "string"
+      userStatus:
+        type: "integer"
+        format: "int32"
+        description: "User Status"
+    xml:
+      name: "User"
+  Category:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      name:
+        type: "string"
+    xml:
+      name: "Category"
+  Tag:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      name:
+        type: "string"
+    xml:
+      name: "Tag"
+  ApiResponse:
+    type: "object"
+    properties:
+      code:
+        type: "integer"
+        format: "int32"
+      type:
+        type: "string"
+      message:
+        type: "string"
+  Pet:
+    type: "object"
+    required:
+    - "name"
+    - "photoUrls"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      category:
+        $ref: "#/definitions/Category"
+      name:
+        type: "string"
+        example: "doggie"
+      photoUrls:
+        type: "array"
+        xml:
+          name: "photoUrl"
+          wrapped: true
+        items:
+          type: "string"
+      tags:
+        type: "array"
+        xml:
+          name: "tag"
+          wrapped: true
+        items:
+          $ref: "#/definitions/Tag"
+      status:
+        type: "string"
+        description: "pet status in the store"
+        enum:
+        - "available"
+        - "pending"
+        - "sold"
+    xml:
+      name: "Pet"
+externalDocs:
+  description: "Find out more about Swagger"
+  url: "http://swagger.io"

--- a/test-data/2.0/simple/swagger.yaml
+++ b/test-data/2.0/simple/swagger.yaml
@@ -1,0 +1,11 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Simple
+paths:
+  /ping:
+    get:
+      operationId: ping
+      responses:
+        200:
+          description: pong

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -24,7 +24,11 @@ def register_spec(swagger_dict, response_spec=None, spec_type='json'):
         serialize_function = json.dumps
         content_type = 'application/json'
     headers = 'Content-Type: {0}'.format(content_type)
-    register_get(API_DOCS_URL, body=serialize_function(swagger_dict), headers=headers)
+    register_get(
+        API_DOCS_URL,
+        body=serialize_function(swagger_dict),
+        headers=headers,
+    )
 
 
 @pytest.fixture

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -3,6 +3,7 @@ import json
 
 import httpretty
 import pytest
+import yaml
 
 
 API_DOCS_URL = "http://localhost/api-docs"
@@ -11,11 +12,19 @@ API_DOCS_URL = "http://localhost/api-docs"
 register_get = functools.partial(httpretty.register_uri, httpretty.GET)
 
 
-def register_spec(swagger_dict, response_spec=None):
+def register_spec(swagger_dict, response_spec=None, spec_type='json'):
     if response_spec is not None:
         response_specs = swagger_dict['paths']['/test_http']['get']['responses']
         response_specs['200']['schema'] = response_spec
-    register_get(API_DOCS_URL, body=json.dumps(swagger_dict))
+
+    if spec_type == 'yaml':
+        serialize_function = yaml.dump
+        content_type = 'application/yaml'
+    else:
+        serialize_function = json.dumps
+        content_type = 'application/json'
+    headers = 'Content-Type: {0}'.format(content_type)
+    register_get(API_DOCS_URL, body=serialize_function(swagger_dict), headers=headers)
 
 
 @pytest.fixture

--- a/tests/functional/model_func_test.py
+++ b/tests/functional/model_func_test.py
@@ -4,6 +4,7 @@ Functional tests related to passing models in req/response
 import httpretty
 from jsonschema.exceptions import ValidationError
 import pytest
+import yaml
 
 from bravado.compat import json
 from bravado.client import SwaggerClient
@@ -91,8 +92,15 @@ def swagger_dict():
     }
 
 
-def test_model_in_response(httprettified, swagger_dict, sample_model):
-    register_spec(swagger_dict)
+@pytest.mark.parametrize(
+    'spec_type',
+    (
+        ('json',),
+        ('yaml',),
+    )
+)
+def test_model_in_response(httprettified, swagger_dict, sample_model, spec_type):
+    register_spec(swagger_dict, spec_type=spec_type)
     register_get("http://localhost/test_http", body=json.dumps(sample_model))
     client = SwaggerClient.from_url(API_DOCS_URL)
     result = client.api_test.testHTTP().result()

--- a/tests/functional/model_func_test.py
+++ b/tests/functional/model_func_test.py
@@ -4,7 +4,6 @@ Functional tests related to passing models in req/response
 import httpretty
 from jsonschema.exceptions import ValidationError
 import pytest
-import yaml
 
 from bravado.compat import json
 from bravado.client import SwaggerClient
@@ -99,7 +98,8 @@ def swagger_dict():
         ('yaml',),
     )
 )
-def test_model_in_response(httprettified, swagger_dict, sample_model, spec_type):
+def test_model_in_response(
+        httprettified, swagger_dict, sample_model, spec_type):
     register_spec(swagger_dict, spec_type=spec_type)
     register_get("http://localhost/test_http", body=json.dumps(sample_model))
     client = SwaggerClient.from_url(API_DOCS_URL)

--- a/tests/swagger_model/load_file_test.py
+++ b/tests/swagger_model/load_file_test.py
@@ -8,7 +8,26 @@ def test_success():
     assert '2.0' == spec_json['swagger']
 
 
-def test_non_existant_file():
+@pytest.mark.parametrize(
+    'filename',
+    (
+        ('test-data/2.0/simple/swagger.yaml'),
+        ('test-data/2.0/petstore/swagger.yaml'),
+    ),
+)
+def test_success_yaml(filename):
+    spec_yaml = load_file(filename)
+    assert '2.0' == spec_yaml['swagger']
+
+
+def test_spec_internal_representation_identical():
+    spec_json = load_file('test-data/2.0/petstore/swagger.json')
+    spec_yaml = load_file('test-data/2.0/petstore/swagger.json')
+
+    assert spec_yaml == spec_json
+
+
+def test_non_existent_file():
     with pytest.raises(IOError) as excinfo:
         load_file('test-data/2.0/i_dont_exist.json')
     assert 'No such file or directory' in str(excinfo.value)

--- a/tests/swagger_model/load_file_test.py
+++ b/tests/swagger_model/load_file_test.py
@@ -22,7 +22,7 @@ def test_success_yaml(filename):
 
 def test_spec_internal_representation_identical():
     spec_json = load_file('test-data/2.0/petstore/swagger.json')
-    spec_yaml = load_file('test-data/2.0/petstore/swagger.json')
+    spec_yaml = load_file('test-data/2.0/petstore/swagger.yaml')
 
     assert spec_yaml == spec_json
 

--- a/tests/swagger_model/loader_test.py
+++ b/tests/swagger_model/loader_test.py
@@ -1,0 +1,43 @@
+import pytest
+
+from bravado.swagger_model import Loader
+
+
+@pytest.fixture
+def yaml_spec():
+    return """swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Simple
+paths:
+  /ping:
+    get:
+      operationId: ping
+      responses:
+        200:
+          description: pong"""
+
+
+def test_load_yaml(yaml_spec):
+    loader = Loader(None)
+    result = loader.load_yaml(yaml_spec)
+
+    assert result == {
+        'swagger': '2.0',
+        'info': {
+            'version': '1.0.0',
+            'title': 'Simple',
+        },
+        'paths': {
+            '/ping': {
+                'get': {
+                    'operationId': 'ping',
+                    'responses': {
+                        '200': {
+                            'description': 'pong',
+                        },
+                    },
+                },
+            },
+        },
+    }


### PR DESCRIPTION
My goal is to stay compatible with the YAML specs in the [OpenAPI repository](https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v2.0/yaml). This necessitates the cast of HTML status codes to strings, since otherwise there will be an exception when trying to use the parsed spec.

Closes Yelp/bravado#168