### PR TITLE
Fix unit test to not expect default values to be sent in request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,8 @@ Changelog
 ------------------
 - Support for YAML Swagger specs
 - Remove pytest-mock dependency from requirements-dev.txt. No longer used and it was breaking the build.
-- Requires bravado-core >= 4.1.0
+- Requires bravado-core >= 4.2.2
+- Fix unit test for default values getting sent in the request
 
 8.0.1 (2015-12-02)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright (c) 2013, Digium, Inc.
-# Copyright (c) 2014-2015, Yelp, Inc.
+# Copyright (c) 2014-2016, Yelp, Inc.
 
 import os
 
@@ -30,7 +30,7 @@ setup(
         "Programming Language :: Python :: 3.4",
     ],
     install_requires=[
-        "bravado-core >= 4.1.0",
+        "bravado-core >= 4.2.2",
         "crochet >= 1.4.0",
         "fido >= 2.1.0",
         "python-dateutil",

--- a/tests/functional/request_func_test.py
+++ b/tests/functional/request_func_test.py
@@ -1,9 +1,8 @@
 """
 Request related functional tests
 """
-from six.moves import cStringIO
-
 import httpretty
+from six.moves import cStringIO
 from six.moves.urllib import parse as urlparse
 
 from bravado.client import SwaggerClient
@@ -76,13 +75,15 @@ def test_parameter_in_path_of_request(httprettified, swagger_dict):
     assert resource.testHTTP(test_param="foo", param_id="42").result() is None
 
 
-def test_default_value_in_request(httprettified, swagger_dict):
+def test_default_value_not_in_request(httprettified, swagger_dict):
+    # Default should be applied on the server side so no need to send it in
+    # the request.
     swagger_dict['paths']['/test_http']['get']['parameters'][0]['default'] = 'X'
     register_spec(swagger_dict)
     register_get("http://localhost/test_http?")
     resource = SwaggerClient.from_url(API_DOCS_URL).api_test
     resource.testHTTP().result()
-    assert ['X'] == httpretty.last_request().querystring['test_param']
+    assert 'test_param' not in httpretty.last_request().querystring
 
 
 def test_array_with_collection_format_in_path_of_request(

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ commands =
 deps =
     {[testenv]deps}
     sphinx
+    sphinx-rtd-theme
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html
 


### PR DESCRIPTION
Pretty self explanatory.  This broke when upgrading to bravado-core 4.2.2