### PR TITLE
Only require old twisted in py26

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ setup(
         "pyyaml",
         "requests",
         "six",
-        "twisted >= 14.0.0, < 15.5.0", # Python 2.6 support was dropped in 15.5.0
     ],
+    extras_require={
+        ':python_version=="2.6"': ['twisted >= 14.0.0, < 15.5'],
+        ':python_version!="2.6"': ['twisted >= 14.0.0'],
+    },
 )


### PR DESCRIPTION
This uses some newer features of pip/wheel/setuptools
- Installing from source in pip1.5 won't work
- Installing from wheel will