### PR TITLE
Only require old twisted in py26

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
         "pyyaml",
         "requests",
         "six",
-        "twisted >= 14.0.0, < 15.5.0", # Python 2.6 support was dropped in 15.5.0
+        "twisted >= 14.0.0",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,11 @@ deps =
 commands =
     py.test --capture=no {posargs:tests}
 
+[testenv:py26]
+deps =
+    twisted<15.5
+    {[testenv]deps}
+
 [testenv:flake8]
 deps = flake8
 commands =


### PR DESCRIPTION
Like #208

- Can use old-ass pip
- Requires more user intervention if they're using py26