### PR TITLE
Fido 3.0.0 - EventualResult instead of concurrent futures - Fix requests unicode bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 Changelog
 =========
+8.2.0 (2016-04-29)
+------------------
+- Bravado compliant to Fido 3.0.0 
+- Dropped use of concurrent futures in favor of crochet EventualResult
+- Workaround for bypassing a unicode bug in python `requests` < 2.8.1
+
 8.1.2 (2016-04-18)
 ------------------
 - Don't unnecessarily constrain the version of twisted when not using python 2.6

--- a/bravado/__init__.py
+++ b/bravado/__init__.py
@@ -1,1 +1,1 @@
-version = '8.1.2'
+version = '8.2.0'

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -118,7 +118,7 @@ class FidoClient(HttpClient):
             # converting to string for `requests` method is necessary when
             # using requests < 2.8.1 due to a bug while handling unicode values
             # See changelog 2.8.1 at https://pypi.python.org/pypi/requests
-            'method': str(prepared_request.method) or 'GET',
+            'method': str(prepared_request.method or 'GET'),
             'body': prepared_request.body,
             'headers': prepared_request.headers,
             'url': prepared_request.url,

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -10,6 +10,7 @@ if six.PY3:
 import fido
 from bravado_core.response import IncomingResponse
 from bravado.http_client import HttpClient
+from bravado.http_future import FutureAdapter
 from bravado.http_future import HttpFuture
 
 log = logging.getLogger(__name__)
@@ -70,9 +71,9 @@ class FidoClient(HttpClient):
 
         request_for_twisted = self.prepare_request_for_twisted(request_params)
 
-        concurrent_future = fido.fetch(**request_for_twisted)
+        future_adapter = FidoFutureAdapter(fido.fetch(**request_for_twisted))
 
-        return HttpFuture(concurrent_future,
+        return HttpFuture(future_adapter,
                           FidoResponseAdapter,
                           operation,
                           response_callbacks,
@@ -114,7 +115,10 @@ class FidoClient(HttpClient):
         prepared_request.headers.pop('Content-Length', None)
 
         request_for_twisted = {
-            'method': prepared_request.method or 'GET',
+            # converting to string for `requests` method is necessary when
+            # using requests < 2.8.1 due to a bug while handling unicode values
+            # See changelog 2.8.1 at https://pypi.python.org/pypi/requests
+            'method': str(prepared_request.method) or 'GET',
             'body': prepared_request.body,
             'headers': prepared_request.headers,
             'url': prepared_request.url,
@@ -125,3 +129,17 @@ class FidoClient(HttpClient):
                 request_for_twisted[fetch_kwarg] = request_params[fetch_kwarg]
 
         return request_for_twisted
+
+
+class FidoFutureAdapter(FutureAdapter):
+    """
+    This is just a wrapper for an EventualResult object from crochet.
+    It implements the 'result' method which is needed by our HttpFuture to
+    retrieve results.
+    """
+
+    def __init__(self, eventual_result):
+        self._eventual_result = eventual_result
+
+    def result(self, timeout=None):
+        return self._eventual_result.wait(timeout=timeout)

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -138,8 +138,7 @@ class RequestsClient(HttpClient):
         requests_future = RequestsFutureAdapter(
             self.session,
             self.authenticated_request(sanitized_params),
-            misc_options
-        )
+            misc_options)
 
         return HttpFuture(
             requests_future,

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -7,6 +7,7 @@ import requests.auth
 from six.moves.urllib import parse as urlparse
 
 from bravado.http_client import HttpClient
+from bravado.http_future import FutureAdapter
 from bravado.http_future import HttpFuture
 
 
@@ -137,7 +138,8 @@ class RequestsClient(HttpClient):
         requests_future = RequestsFutureAdapter(
             self.session,
             self.authenticated_request(sanitized_params),
-            misc_options)
+            misc_options
+        )
 
         return HttpFuture(
             requests_future,
@@ -193,7 +195,7 @@ class RequestsResponseAdapter(IncomingResponse):
         return self._delegate.json(**kwargs)
 
 
-class RequestsFutureAdapter(object):
+class RequestsFutureAdapter(FutureAdapter):
     """Mimics a :class:`concurrent.futures.Future` for the purposes of making
     HTTP calls with the Requests library in a future-y sort of way.
     """

--- a/tests/http_future/HttpFuture/result_test.py
+++ b/tests/http_future/HttpFuture/result_test.py
@@ -1,6 +1,6 @@
 from bravado_core.operation import Operation
 from bravado_core.response import IncomingResponse
-from concurrent.futures import Future
+from bravado.http_future import FutureAdapter
 from mock import patch, Mock
 import pytest
 
@@ -11,7 +11,7 @@ def test_200_get_swagger_spec():
     response_adapter_instance = Mock(spec=IncomingResponse, status_code=200)
     response_adapter_type = Mock(return_value=response_adapter_instance)
     http_future = HttpFuture(
-        concurrent_future=Mock(spec=Future),
+        future=Mock(spec=FutureAdapter),
         response_adapter=response_adapter_type)
 
     assert response_adapter_instance == http_future.result()
@@ -23,7 +23,7 @@ def test_500_get_swagger_spec():
 
     with pytest.raises(HTTPError) as excinfo:
         HttpFuture(
-            concurrent_future=Mock(spec=Future),
+            future=Mock(spec=FutureAdapter),
             response_adapter=response_adapter_type).result()
 
     assert excinfo.value.response.status_code == 500
@@ -39,7 +39,7 @@ def test_200_service_call(_):
     response_adapter_type = Mock(return_value=response_adapter_instance)
 
     http_future = HttpFuture(
-        concurrent_future=Mock(spec=Future),
+        future=Mock(spec=FutureAdapter),
         response_adapter=response_adapter_type,
         operation=Mock(spec=Operation))
 
@@ -56,7 +56,7 @@ def test_400_service_call(mock_unmarshal_response):
     response_adapter_type = Mock(return_value=response_adapter_instance)
 
     http_future = HttpFuture(
-        concurrent_future=Mock(spec=Future),
+        future=Mock(spec=FutureAdapter),
         response_adapter=response_adapter_type,
         operation=Mock(spec=Operation))
 
@@ -76,7 +76,7 @@ def test_also_return_response_true(_):
     response_adapter_type = Mock(return_value=response_adapter_instance)
 
     http_future = HttpFuture(
-        concurrent_future=Mock(spec=Future),
+        future=Mock(spec=FutureAdapter),
         response_adapter=response_adapter_type,
         operation=Mock(spec=Operation),
         also_return_response=True)

--- a/tests/integration/fido_client_test.py
+++ b/tests/integration/fido_client_test.py
@@ -76,10 +76,10 @@ class TestServer():
             'params': {},
         }
 
-        eventual_one = self.fido_client.request(request_one_params)
-        eventual_two = self.fido_client.request(request_two_params)
-        resp_one = eventual_one.result(timeout=1)
-        resp_two = eventual_two.result(timeout=1)
+        http_future_1 = self.fido_client.request(request_one_params)
+        http_future_2 = self.fido_client.request(request_two_params)
+        resp_one = http_future_1.result(timeout=1)
+        resp_two = http_future_2.result(timeout=1)
 
         assert resp_one.text == ROUTE_1_RESPONSE
         assert resp_two.text == ROUTE_2_RESPONSE
@@ -93,7 +93,7 @@ class TestServer():
             'data': {"number": 3},
         }
 
-        eventual = self.fido_client.request(request_args)
-        resp = eventual.result(timeout=1)
+        http_future = self.fido_client.request(request_args)
+        resp = http_future.result(timeout=1)
 
         assert resp.text == '6'


### PR DESCRIPTION
**Upgrade bravado to use fido 3.0.0**
This change makes bravado capable of handling EventualResult objects which are now returned by Fido instead of a concurrent.futures.
I acted on our FutureAdaptor layer of abstraction by creating FidoFutureAdapter and making it and RequestFutureAdapter 'implement' FutureAdapter.

**Requests bug**
I also introduced a minor little workaround caused by a bug in 'requests' version < 2.8.1  which is documented in their changelog at https://pypi.python.org/pypi/requests

**Tests**
Testing might be broken on github until fido gets updated to 3.0.0 in https://pypi.python.org/simple/fido/
I manually tested with fido 3.0.0 and our internal acceptance suite though and it was all green.
