### PR TITLE
Pinpoint fido version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=[
         "bravado-core >= 4.2.2",
         "crochet >= 1.4.0",
-        "fido >= 2.1.0",
+        "fido >= 2.1.0, < 3.2.0",
         "python-dateutil",
         "pyyaml",
         "requests",


### PR DESCRIPTION
Avoid breaking the build in case of backward incompatible changes (fido 3.2.0 should be py3 ready)