### PR TITLE
fix required fields for header

### DIFF
--- a/bravado/client.py
+++ b/bravado/client.py
@@ -314,7 +314,7 @@ def construct_params(operation, request, op_kwargs):
 
     # Check required params and non-required params with a 'default' value
     for remaining_param in itervalues(current_params):
-        if remaining_param.required:
+        if remaining_param.required and remaining_param.location != 'header':
             raise SwaggerMappingError(
                 '{0} is a required parameter'.format(remaining_param.name))
         if not remaining_param.required and remaining_param.has_default():


### PR DESCRIPTION
I'm sure this is not the correct way to fix this, but I was not sure

When you have this in one of your swagger parameters
```
{                                                                                                                                                                                                                                                                       
            "name": "Authorization",                                                                                                                                                                                                                                              
            "in": "header",                                                                                                                                                                                                                                                       
            "description": "Basic Auth access token.",                                                                                                                                                                                                                            
            "required": true,                                                                                                                                                                                                                                                     
            "type": "string"                                                                                                                                                                                                                                                      
},    
```

you will get 

```
SwaggerMappingError: Authorization is a required parameter
```

even with

```
headers = {                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
            'Authorization': 'asdfaf'                                                                                                                                                                                                                                   
}
create_response = self.client.testthing.post_testthing(                                                                                                                                                                                                   
            body=self.thing,
            _request_options={                                                                                                                                                                                                                                                    
                "headers": headers                                                                                                                                                                                              
            }                                                                                                                                                                                                                                                                     
)             
```