### PR TITLE
Bravado can use fido python 3 ready

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@ Changelog
 =========
 8.2.0 (2016-04-29)
 ------------------
+- Bravado using Fido 3.2.0 python 3 ready
+
+8.2.0 (2016-04-29)
+------------------
 - Bravado compliant to Fido 3.0.0 
 - Dropped use of concurrent futures in favor of crochet EventualResult
 - Workaround for bypassing a unicode bug in python `requests` < 2.8.1

--- a/bravado/__init__.py
+++ b/bravado/__init__.py
@@ -1,1 +1,1 @@
-version = '8.2.0'
+version = '8.3.0'

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -2,7 +2,6 @@
 import logging
 
 import requests
-import six
 
 import fido
 from bravado_core.response import IncomingResponse
@@ -117,7 +116,8 @@ class FidoClient(HttpClient):
             # using requests < 2.8.1 due to a bug while handling unicode values
             # See changelog 2.8.1 at https://pypi.python.org/pypi/requests
             'method': str(prepared_request.method or 'GET'),
-            'body': to_bytes(prepared_request.body) if prepared_request.body is not None else None,
+            'body': to_bytes(prepared_request.body) if prepared_request.body \
+            is not None else None,
             'headers': prepared_request.headers,
             'url': prepared_request.url,
         }

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -116,8 +116,10 @@ class FidoClient(HttpClient):
             # using requests < 2.8.1 due to a bug while handling unicode values
             # See changelog 2.8.1 at https://pypi.python.org/pypi/requests
             'method': str(prepared_request.method or 'GET'),
-            'body': to_bytes(prepared_request.body) if prepared_request.body \
-            is not None else None,
+            'body': (
+                to_bytes(prepared_request.body)
+                if prepared_request.body is not None else None
+            ),
             'headers': prepared_request.headers,
             'url': prepared_request.url,
         }

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -9,6 +9,7 @@ from bravado_core.response import IncomingResponse
 from bravado.http_client import HttpClient
 from bravado.http_future import FutureAdapter
 from bravado.http_future import HttpFuture
+from yelp_bytes import to_bytes
 
 log = logging.getLogger(__name__)
 
@@ -116,7 +117,7 @@ class FidoClient(HttpClient):
             # using requests < 2.8.1 due to a bug while handling unicode values
             # See changelog 2.8.1 at https://pypi.python.org/pypi/requests
             'method': str(prepared_request.method or 'GET'),
-            'body': prepared_request.body,
+            'body': to_bytes(prepared_request.body) if prepared_request.body is not None else None,
             'headers': prepared_request.headers,
             'url': prepared_request.url,
         }

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -4,9 +4,6 @@ import logging
 import requests
 import six
 
-if six.PY3:
-    raise ImportError("The fido client is not yet supported in py3")
-
 import fido
 from bravado_core.response import IncomingResponse
 from bravado.http_client import HttpClient

--- a/bravado/swagger_model.py
+++ b/bravado/swagger_model.py
@@ -31,7 +31,7 @@ class FileEventual(object):
             self.headers = {}
 
         def json(self):
-            return json.loads(self.text)
+            return json.loads(self.text.decode('utf-8'))
 
     def __init__(self, path):
         self.path = path

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Unit test dependencies
 bottle
-httpretty==0.8.6
+httpretty==0.8.14
 mock<1.1.0
 pre-commit
 pytest

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=[
         "bravado-core >= 4.2.2",
         "crochet >= 1.4.0",
-        "fido >= 2.1.0, <= 3.2.0",
+        "fido >= 2.1.0, < 3.3.0",
         "yelp_bytes",
         "python-dateutil",
         "pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=[
         "bravado-core >= 4.2.2",
         "crochet >= 1.4.0",
-        "fido >= 2.1.0, < 3.3.0",
+        "fido >= 2.1.0",
         "yelp_bytes",
         "python-dateutil",
         "pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
     install_requires=[
         "bravado-core >= 4.2.2",
         "crochet >= 1.4.0",
-        "fido >= 2.1.0, < 3.2.0",
+        "fido >= 2.1.0, <= 3.2.0",
+        "yelp_bytes",
         "python-dateutil",
         "pyyaml",
         "requests",

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -1,6 +1,6 @@
 import os
 
-import simplejson as json
+from bravado.compat import json
 import pytest
 
 from bravado.client import Spec

--- a/tests/fido_client/FidoClient/prepare_request_for_twisted_test.py
+++ b/tests/fido_client/FidoClient/prepare_request_for_twisted_test.py
@@ -4,10 +4,6 @@ Not Tested:
 1) Callbacks triggered by twisted and crochet
 2) Timeouts by crochet's wait()
 """
-from mock import Mock
-
-import pytest
-import six
 
 from bravado.fido_client import FidoClient
 

--- a/tests/fido_client/FidoClient/prepare_request_for_twisted_test.py
+++ b/tests/fido_client/FidoClient/prepare_request_for_twisted_test.py
@@ -9,16 +9,9 @@ from mock import Mock
 import pytest
 import six
 
-try:
-    from bravado.fido_client import FidoClient
-except ImportError:
-    FidoClient = Mock()  # Tests will be skipped in py3
+from bravado.fido_client import FidoClient
 
 
-@pytest.mark.skipif(
-    six.PY3,
-    reason="Fido client is not usable in py3 until twisted supports it",
-)
 def test_prepare_request_for_twisted():
     request_params = dict(
         url='http://example.com/api-docs',
@@ -36,10 +29,6 @@ def test_prepare_request_for_twisted():
     }
 
 
-@pytest.mark.skipif(
-    six.PY3,
-    reason="Fido client is not usable in py3 until twisted supports it",
-)
 def test_prepare_request_for_twisted_timeouts_added():
     request_params = dict(
         url='http://example.com/api-docs', timeout=15, connect_timeout=15)

--- a/tests/fido_client/FidoClient/prepare_request_for_twisted_test.py
+++ b/tests/fido_client/FidoClient/prepare_request_for_twisted_test.py
@@ -12,7 +12,20 @@ import six
 from bravado.fido_client import FidoClient
 
 
-def test_prepare_request_for_twisted():
+def test_prepare_request_for_twisted_get():
+    request_params = dict(
+        url='http://example.com/api-docs')
+    request_for_twisted = FidoClient.prepare_request_for_twisted(request_params)
+
+    assert request_for_twisted == {
+        'body': None,
+        'headers': {},
+        'method': 'GET',
+        'url': 'http://example.com/api-docs',
+    }
+
+
+def test_prepare_request_for_twisted_body_is_bytes():
     request_params = dict(
         url='http://example.com/api-docs',
         method='POST',
@@ -22,7 +35,7 @@ def test_prepare_request_for_twisted():
     request_for_twisted = FidoClient.prepare_request_for_twisted(request_params)
 
     assert request_for_twisted == {
-        'body': 42,
+        'body': b'42',
         'headers': {'Content-Type': 'application/x-www-form-urlencoded'},
         'method': 'POST',
         'url': 'http://example.com/api-docs?username=yelp'

--- a/tests/fido_client/FidoClient/prepare_request_for_twisted_test.py
+++ b/tests/fido_client/FidoClient/prepare_request_for_twisted_test.py
@@ -9,8 +9,9 @@ from bravado.fido_client import FidoClient
 
 
 def test_prepare_request_for_twisted_get():
-    request_params = dict(
-        url='http://example.com/api-docs')
+    request_params = {
+        'url': 'http://example.com/api-docs'
+    }
     request_for_twisted = FidoClient.prepare_request_for_twisted(request_params)
 
     assert request_for_twisted == {
@@ -22,12 +23,12 @@ def test_prepare_request_for_twisted_get():
 
 
 def test_prepare_request_for_twisted_body_is_bytes():
-    request_params = dict(
-        url='http://example.com/api-docs',
-        method='POST',
-        data=42,
-        params={'username': 'yelp'},
-    )
+    request_params = {
+        'url': 'http://example.com/api-docs',
+        'method': 'POST',
+        'data': 42,
+        'params': {'username': 'yelp'},
+    }
     request_for_twisted = FidoClient.prepare_request_for_twisted(request_params)
 
     assert request_for_twisted == {
@@ -39,8 +40,11 @@ def test_prepare_request_for_twisted_body_is_bytes():
 
 
 def test_prepare_request_for_twisted_timeouts_added():
-    request_params = dict(
-        url='http://example.com/api-docs', timeout=15, connect_timeout=15)
+    request_params = {
+        'url': 'http://example.com/api-docs',
+        'timeout': 15,
+        'connect_timeout': 15
+    }
     request_for_twisted = FidoClient.prepare_request_for_twisted(request_params)
 
     assert request_for_twisted == {

--- a/tests/fido_client/FidoClient/request_test.py
+++ b/tests/fido_client/FidoClient/request_test.py
@@ -1,14 +1,8 @@
 import mock
-from mock import patch, Mock
-
-import pytest
-import six
+from mock import patch
 
 
-try:
-    from bravado.fido_client import FidoClient
-except ImportError:
-    FidoClient = Mock()
+from bravado.fido_client import FidoClient
 
 
 def test_request_no_timeouts_passed_to_fido():

--- a/tests/fido_client/FidoClient/request_test.py
+++ b/tests/fido_client/FidoClient/request_test.py
@@ -11,7 +11,6 @@ except ImportError:
     FidoClient = Mock()
 
 
-@pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
 def test_request_no_timeouts_passed_to_fido():
     with patch('bravado.fido_client.fido.fetch') as fetch:
         request_params = dict(url='http://foo.com/')
@@ -24,7 +23,6 @@ def test_request_no_timeouts_passed_to_fido():
         )
 
 
-@pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
 def test_request_timeout_passed_to_fido():
     with patch('bravado.fido_client.fido.fetch') as fetch:
         request_params = dict(url='http://foo.com/', timeout=1)
@@ -38,7 +36,6 @@ def test_request_timeout_passed_to_fido():
         )
 
 
-@pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
 def test_request_connect_timeout_passed_to_fido():
     with patch('bravado.fido_client.fido.fetch') as fetch:
         request_params = dict(url='http://foo.com/', connect_timeout=1)
@@ -52,7 +49,6 @@ def test_request_connect_timeout_passed_to_fido():
         )
 
 
-@pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
 def test_request_connect_timeout_and_timeout_passed_to_fido():
     with patch('bravado.fido_client.fido.fetch') as fetch:
         request_params = dict(url='http://foo.com/', connect_timeout=1,

--- a/tests/functional/model_func_test.py
+++ b/tests/functional/model_func_test.py
@@ -2,11 +2,12 @@
 Functional tests related to passing models in req/response
 """
 import httpretty
-from jsonschema.exceptions import ValidationError
 import pytest
 
-from bravado.compat import json
+from jsonschema.exceptions import ValidationError
+
 from bravado.client import SwaggerClient
+from bravado.compat import json
 from tests.functional.conftest import register_spec, register_get, API_DOCS_URL
 
 
@@ -183,5 +184,5 @@ def test_model_in_body_of_request(httprettified, swagger_dict, sample_model):
     School = client.get_model('School')
     user = User(id=42, schools=[School(name='s1')])
     resource.testHTTPPost(body=user).result()
-    body = json.loads(httpretty.last_request().body)
+    body = json.loads(httpretty.last_request().body.decode('utf-8'))
     assert {'schools': [{'name': 's1'}], 'id': 42} == body

--- a/tests/integration/fido_client_test.py
+++ b/tests/integration/fido_client_test.py
@@ -5,8 +5,6 @@ import threading
 import time
 
 import bottle
-import pytest
-import six
 
 from bravado.fido_client import FidoClient
 

--- a/tests/integration/fido_client_test.py
+++ b/tests/integration/fido_client_test.py
@@ -8,10 +8,7 @@ import bottle
 import pytest
 import six
 
-try:
-    from bravado.fido_client import FidoClient
-except ImportError:
-    pass  # Tests will be skipped in py3
+from bravado.fido_client import FidoClient
 
 ROUTE_1_RESPONSE = "HEY BUDDY"
 ROUTE_2_RESPONSE = "BYE BUDDY"
@@ -51,7 +48,6 @@ def launch_threaded_http_server(port):
     return thread
 
 
-@pytest.mark.skipif(six.PY3, reason="twisted doesnt support py3 yet")
 class TestServer():
 
     @classmethod

--- a/tests/integration/fido_client_test.py
+++ b/tests/integration/fido_client_test.py
@@ -10,8 +10,8 @@ import six
 
 from bravado.fido_client import FidoClient
 
-ROUTE_1_RESPONSE = "HEY BUDDY"
-ROUTE_2_RESPONSE = "BYE BUDDY"
+ROUTE_1_RESPONSE = b"HEY BUDDY"
+ROUTE_2_RESPONSE = b"BYE BUDDY"
 
 
 @bottle.route("/1")
@@ -92,4 +92,4 @@ class TestServer():
         http_future = self.fido_client.request(request_args)
         resp = http_future.result(timeout=1)
 
-        assert resp.text == '6'
+        assert resp.text == b'6'


### PR DESCRIPTION
Enabling use of the new Fido client python3 ready. Let's have bravado use it.

I upgraded bottle to a more recent version where [issue221](https://github.com/gabrielfalcao/HTTPretty/issues/221) is fixed.
Using now bytes for the request body as requested by fido 3.2.0 

@akanak 