### PR TITLE
Pinning requirements for testing

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ httpretty==0.8.14
 mock<1.1.0
 pre-commit
 pytest
+cryptography==1.3.4

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py26, py27, py34, flake8
 
 [testenv]
 deps =
+    py26: twisted==15.4
     -rrequirements-dev.txt
 commands =
     py.test --capture=no {posargs:tests}


### PR DESCRIPTION
Our jenkins tests bravado on lucid, and has been failing to install the latest cryptography. This pins that version.

Also, even though twisted is restricted to old versions for python 2.6 in setup.py, it was still installing new versions in tox environments, so I pinned that as well for python 2.6