### PR TITLE
Pin cryptography to 1.3.4 so we can build on lucid

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ httpretty==0.8.14
 mock<1.1.0
 pre-commit
 pytest
+cryptography==1.3.4


### PR DESCRIPTION
Our Jenkins tests bravado on lucid, and has been failing to install the latest cryptography because the latest release drops support for OpenSSL 0.9.8, the newest release for lucid. This pins cryptography 1.3.4.