### PR TITLE
Relax dev requirements; we should try not to pin these

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Unit test dependencies
 bottle
-httpretty==0.8.14
-mock<1.1.0
+httpretty
+mock
 pre-commit
 pytest


### PR DESCRIPTION
Tests pass locally with mock 2.0. I also don't think we have a hard dependency on the latest version of httpretty.