### PR TITLE
correctly handle async POST requests in swaggerpy + py3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,8 @@
 [report]
 exclude_lines =
+    # Have to re-enable the standard pragma
+    \#\s*pragma: no cover
+
     def __repr__
     raise AssertionError
     raise NotImplementedError

--- a/swaggerpy/async_http_client.py
+++ b/swaggerpy/async_http_client.py
@@ -55,10 +55,18 @@ class AsynchronousHttpClient(http_client.HttpClient):
             method=request_params.get('method')
         )
 
+        if isinstance(
+            prepared_request.body,
+            six.text_type,
+        ):  # pragma: no cover (PY2)
+            body_bytes = prepared_request.body.encode('utf-8')
+        else:
+            body_bytes = prepared_request.body
+
         request_for_crochet = {
             'method': prepared_request.method or 'GET',
-            'bodyProducer': FileBodyProducer(BytesIO(prepared_request.body))
-            if prepared_request.body else None,
+            'bodyProducer': FileBodyProducer(BytesIO(body_bytes))
+            if body_bytes else None,
             'headers': listify_headers(prepared_request.headers),
             'uri': prepared_request.url,
         }

--- a/tests/integration/async_http_client_test.py
+++ b/tests/integration/async_http_client_test.py
@@ -26,6 +26,12 @@ def two():
     return ROUTE_2_RESPONSE
 
 
+@bottle.route("/post", method="POST")
+def post():
+    name = bottle.request.forms.get("name")
+    return 'Hello {name}! Have a snowman: ☃'.format(name=name)
+
+
 def get_hopefully_free_port():
     s = socket.socket()
     s.bind(('', 0))
@@ -73,6 +79,27 @@ class TestServer(unittest.TestCase):
 
         self.assertEqual(resp_one.text, ROUTE_1_RESPONSE)
         self.assertEqual(resp_two.text, ROUTE_2_RESPONSE)
+
+    def test_make_post_request(self):
+        port = get_hopefully_free_port()
+        launch_threaded_http_server(port)
+
+        client = AsynchronousHttpClient()
+
+        request_params = {
+            'method': b'POST',
+            'headers': {},
+            'url': "http://localhost:{0}/post".format(port),
+            'data': {'name': 'Matt'},
+        }
+
+        future = client.start_request(request_params)
+        response = future.wait(timeout=1)
+
+        self.assertEqual(
+            response.text,
+            u'Hello Matt! Have a snowman: ☃'.encode('utf-8'),
+        )
 
     def test_erroring_request(self):
         port = get_hopefully_free_port()

--- a/tox.ini
+++ b/tox.ini
@@ -14,12 +14,13 @@ commands =
     flake8 swaggerpy tests
 
 [testenv:cover]
+basepython = /usr/bin/python2.7
 deps =
     {[testenv]deps}
     pytest-cov
 commands =
     py.test --cov swaggerpy {posargs:tests}
-    coverage combine
+    coverage combine --append
     coverage report --omit=.tox/*,tests/*,/usr/share/pyshared/*,/usr/lib/pymodules/* -m
 
 [testenv:docs]


### PR DESCRIPTION
`AsynchronousHTTPClient.start_request` fails with a TypeError when the request has any form data in python3, because we assume that the body of the request is a byte string:

```
self = <class 'swaggerpy.async_http_client.AsynchronousHttpClient'>(), request_params = {'data': {'name': 'Matt'}, 'headers': {}, 'method': b'POST', 'url': 'http://localhost:49111/post'}

    def start_request(self, request_params):
        """Sets up the request params as per Twisted Agent needs.
            Sets up crochet and triggers the API request in background

            :param request_params: request parameters for API call
            :type request_params: dict

            :return: crochet EventualResult
            """

        prepared_request = requests.PreparedRequest()
        prepared_request.prepare(
            headers=request_params.get('headers'),
            data=request_params.get('data'),
            params=request_params.get('params'),
            files=request_params.get('files'),
            url=request_params.get('url'),
            method=request_params.get('method')
        )

        request_for_crochet = {
            'method': prepared_request.method or 'GET',
            'bodyProducer': FileBodyProducer(BytesIO(prepared_request.body))
>           if prepared_request.body else None,
            'headers': listify_headers(prepared_request.headers),
            'uri': prepared_request.url,
        }
E       TypeError: 'str' does not support the buffer interface
```

This branch encodes the request body to a byte string if it's unicode.