### PR TITLE
Cleanly cancel the EventualResult on Timeout

### DIFF
--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 import logging
 
+import crochet
 import requests
-
 import fido
+from yelp_bytes import to_bytes
+
 from bravado_core.response import IncomingResponse
 from bravado.http_client import HttpClient
 from bravado.http_future import FutureAdapter
 from bravado.http_future import HttpFuture
-from yelp_bytes import to_bytes
 
 log = logging.getLogger(__name__)
 
@@ -142,4 +143,8 @@ class FidoFutureAdapter(FutureAdapter):
         self._eventual_result = eventual_result
 
     def result(self, timeout=None):
-        return self._eventual_result.wait(timeout=timeout)
+        try:
+            return self._eventual_result.wait(timeout=timeout)
+        except crochet.TimeoutError:
+            self._eventual_result.cancel()
+            raise

--- a/tests/fido_client/FidoFutureAdapter/result_test.py
+++ b/tests/fido_client/FidoFutureAdapter/result_test.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from mock import Mock
+import pytest
+
+import crochet
+
+from bravado.fido_client import FidoFutureAdapter
+
+
+def test_eventual_result_not_cancelled():
+    mock_eventual_result = Mock()
+    adapter = FidoFutureAdapter(mock_eventual_result)
+
+    adapter.result()
+    assert mock_eventual_result.cancel.called is False
+
+
+def test_eventual_result_cancelled_on_exception():
+    mock_eventual_result = Mock(wait=Mock(side_effect=crochet.TimeoutError()))
+    adapter = FidoFutureAdapter(mock_eventual_result)
+
+    with pytest.raises(crochet.TimeoutError):
+        adapter.result()
+
+    assert mock_eventual_result.cancel.called is True

--- a/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
+++ b/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from mock import Mock
 import pytest
 from requests.sessions import Session


### PR DESCRIPTION
When the FidoFutureAdapter incurs in an exception, the eventual_result sticks around and gets cancelled later when we lose pointers to it (in an unclean fashion). 
Logs report lines as:
`CRITICAL:twisted:Unhandled error in EventualResult
Traceback (most recent call last):
Failure: twisted.web._newclient.ResponseNeverReceived: [<twisted.python.failure.Failure twisted.internet.error.ConnectionLost: Connection to the other side was lost in a non-clean fashion: Connection lost.>]`

which basically means the deferred object wasn't closed correctly. This PR closes the deferred before re-raising.

Note that not cancelling the deferred object on result retrieval is a feature from [crochet](https://github.com/Yelp/fido/issues/31). It basically lets the user try again in case of a Timeout. We usually don't want to try again on the same connection as this only prolongs the call in our use case, so we can safely cancel the EventualResult object (and hence the underlying deferred). 

