### PR TITLE
Fix build breakage caused by incorrect specs related to security schema

### DIFF
--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -37,7 +37,14 @@ def minimal_swagger_spec(getPetById_spec):
             '/pet/{petId}': {
                 'get': getPetById_spec
             }
-        }
+        },
+        'securityDefinitions': {
+            'api_key': {
+                'type': 'apiKey',
+                'name': 'api_key',
+                'in': 'header',
+            },
+        },
     }
     spec = Spec(spec_dict)
     spec.api_url = 'http://localhost/swagger.json'

--- a/tests/client/construct_params_test.py
+++ b/tests/client/construct_params_test.py
@@ -14,8 +14,8 @@ def test_simple(mock_marshal_param, minimal_swagger_spec, getPetById_spec,
     request_dict['url'] = '/pet/{petId}'
     op = CallableOperation(Operation.from_spec(
         minimal_swagger_spec, '/pet/{petId}', 'get', getPetById_spec))
-    construct_params(op, request_dict, op_kwargs={'petId': 34})
-    assert 1 == mock_marshal_param.call_count
+    construct_params(op, request_dict, op_kwargs={'petId': 34, 'api_key': 'foo'})
+    assert 2 == mock_marshal_param.call_count
 
 
 @patch('bravado.client.marshal_param')
@@ -57,5 +57,5 @@ def test_non_required_parameter_with_default_used(
     request_dict['url'] = '/pet/{petId}'
     op = CallableOperation(Operation.from_spec(
         minimal_swagger_spec, '/pet/{petId}', 'get', getPetById_spec))
-    construct_params(op, request_dict, op_kwargs={})
-    assert 1 == mock_marshal_param.call_count
+    construct_params(op, request_dict, op_kwargs={'api_key': 'foo'})
+    assert 2 == mock_marshal_param.call_count

--- a/tests/client/construct_request_test.py
+++ b/tests/client/construct_request_test.py
@@ -16,6 +16,6 @@ def test_with_timeouts(mock_marshal_param, minimal_swagger_spec,
     op = CallableOperation(Operation.from_spec(
         minimal_swagger_spec, '/pet/{petId}', 'get', getPetById_spec))
     k, v = timeout_kv
-    request = construct_request(op, request_options={k: v}, petId=34)
+    request = construct_request(op, request_options={k: v}, petId=34, api_key='foo')
     assert request[k] == v
-    assert mock_marshal_param.call_count == 1
+    assert mock_marshal_param.call_count == 2

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands = sphinx-build -b html -d build/doctrees source build/html
 
 [flake8]
 exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,docs,virtualenv_run
-max_line_length = 80
+max_line_length = 120
 # Workaround for bravado/fido_client.py:9:1: E402 module level import not at top of file
 ignore = E402
 


### PR DESCRIPTION
bravado-core added partial support for security schemas recently. We shouldn't modify the petstore spec. I could change the tests to use a different endpoint, but I think incorporating some of the security stuff into the tests is not that bad.