### PR TITLE
Enforced header validation (set through _request_options)

### DIFF
--- a/bravado/client.py
+++ b/bravado/client.py
@@ -314,8 +314,11 @@ def construct_params(operation, request, op_kwargs):
 
     # Check required params and non-required params with a 'default' value
     for remaining_param in itervalues(current_params):
-        if remaining_param.required:
-            raise SwaggerMappingError(
-                '{0} is a required parameter'.format(remaining_param.name))
-        if not remaining_param.required and remaining_param.has_default():
-            marshal_param(remaining_param, None, request)
+        if remaining_param.location == 'header' and remaining_param.name in request['headers']:
+            marshal_param(remaining_param, request['headers'][remaining_param.name], request)
+        else:
+            if remaining_param.required:
+                raise SwaggerMappingError(
+                    '{0} is a required parameter'.format(remaining_param.name))
+            if not remaining_param.required and remaining_param.has_default():
+                marshal_param(remaining_param, None, request)

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -22,7 +22,10 @@ def petstore_client(petstore_dict):
 
 @pytest.fixture
 def request_dict():
-    return {}
+    return {
+        'params': {},
+        'headers': {},
+    }
 
 
 @pytest.fixture

--- a/tests/client/construct_params_test.py
+++ b/tests/client/construct_params_test.py
@@ -26,7 +26,10 @@ def test_no_params(mock_marshal_param, minimal_swagger_spec, request_dict):
         minimal_swagger_spec, '/pet/{petId}', 'get', {}))
     construct_params(op, request_dict, op_kwargs={})
     assert 0 == mock_marshal_param.call_count
-    assert 0 == len(request_dict)
+    assert request_dict == {
+        'params': {},
+        'headers': {},
+    }
 
 
 def test_extra_parameter_error(minimal_swagger_spec, request_dict):
@@ -45,6 +48,16 @@ def test_required_parameter_missing(
     with pytest.raises(SwaggerMappingError) as excinfo:
         construct_params(op, request_dict, op_kwargs={})
     assert 'required parameter' in str(excinfo.value)
+
+
+def test_validate_header_parameter_from_request_options(
+        minimal_swagger_spec, getPetById_spec, request_dict):
+    request_dict['url'] = '/pet/{petId}'
+    request_dict['headers']['api_key'] = 'api_key'
+
+    op = CallableOperation(Operation.from_spec(
+        minimal_swagger_spec, '/pet/{petId}', 'delete', getPetById_spec))
+    construct_params(op, request_dict, op_kwargs={'petId': 1})
 
 
 @patch('bravado.client.marshal_param')

--- a/tests/client/construct_params_test.py
+++ b/tests/client/construct_params_test.py
@@ -50,14 +50,16 @@ def test_required_parameter_missing(
     assert 'required parameter' in str(excinfo.value)
 
 
+@patch('bravado.client.marshal_param')
 def test_validate_header_parameter_from_request_options(
-        minimal_swagger_spec, getPetById_spec, request_dict):
+        mock_marshal_param, minimal_swagger_spec, getPetById_spec, request_dict):
     request_dict['url'] = '/pet/{petId}'
     request_dict['headers']['api_key'] = 'api_key'
 
     op = CallableOperation(Operation.from_spec(
         minimal_swagger_spec, '/pet/{petId}', 'delete', getPetById_spec))
     construct_params(op, request_dict, op_kwargs={'petId': 1})
+    assert 2 == mock_marshal_param.call_count
 
 
 @patch('bravado.client.marshal_param')


### PR DESCRIPTION
I got inspiration by the problem shown by @necrolyte2 on #226 .
Trying to understand his issue I figured out that bravado is not validating the headers injected by ``_request_options``.

That's generally fine, since bravado validates that what is described on the swagger specs is present on the request and response. But @necrolyte2 was injecting some header parameters through ``_request_options`` and bravado was throwing him an exception (``SwaggerMappingError``) because some required header parameters were not set in the parameter list.

The goal of the PR is to add checks on the header parameters, specified in swagger specs, defined through ``_request_options`` instead of [``op_kwargs``](https://github.com/Yelp/bravado/blob/master/bravado/client.py#L295).

The code change should be considered as a backcompatible change.