### PR TITLE
Add more granular exception classes for HTTPError

### DIFF
--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -1,7 +1,24 @@
 # -*- coding: utf-8 -*-
+from six import with_metaclass
 
 
-class HTTPError(IOError):
+status_map = {}
+
+
+def _register_exception(exception_class):
+    status_map[exception_class.status_code] = exception_class
+
+
+class HTTPErrorType(type):
+
+    def __new__(cls, *args, **kwargs):
+        new_class = super(HTTPErrorType, cls).__new__(cls, *args, **kwargs)
+        if hasattr(new_class, 'status_code'):
+            _register_exception(new_class)
+        return new_class
+
+
+class HTTPError(with_metaclass(HTTPErrorType, IOError)):
     """Unified HTTPError used across all http_client implementations.
     """
 
@@ -16,6 +33,7 @@ class HTTPError(IOError):
         self.response = response
         self.message = message
         self.swagger_result = swagger_result
+        self.status_code = getattr(self.response, 'status_code')
 
     def __str__(self):
         # Try to surface the most useful/relevant information available
@@ -26,3 +44,39 @@ class HTTPError(IOError):
         result = ': {0}'.format(self.swagger_result) \
             if self.swagger_result is not None else ''
         return '{0}{1}{2}'.format(status_and_reason, message, result)
+
+
+class HTTPClientError(HTTPError):
+    """4xx responses."""
+
+
+class HTTPBadRequest(HTTPClientError):
+    status_code = 400
+
+
+class HTTPForbidden(HTTPClientError):
+    status_code = 403
+
+
+class HTTPNotFound(HTTPClientError):
+    status_code = 404
+
+
+class HTTPServerError(HTTPError):
+    """5xx responses."""
+
+
+class HTTPInternalServerError(HTTPServerError):
+    status_code = 500
+
+
+def make_http_exception(response, message=None, swagger_result=None):
+    """
+    :type response: :class:`bravado_core.response.IncomingResponse`
+    :param message: Optional string message
+    :param swagger_result: If the response for this HTTPError is
+        documented in the swagger spec, then this should be the result
+        value of the response.
+    """
+    exc_class = status_map.get(response.status_code, HTTPError)
+    return exc_class(response, message=message, swagger_result=swagger_result)

--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -53,42 +53,6 @@ class HTTPError(with_metaclass(HTTPErrorType, IOError)):
         return '{0}{1}{2}'.format(status_and_reason, message, result)
 
 
-class HTTPClientError(HTTPError):
-    """4xx responses."""
-
-
-class HTTPBadRequest(HTTPClientError):
-    status_code = 400
-
-
-class HTTPUnauthorized(HTTPClientError):
-    status_code = 401
-
-
-class HTTPForbidden(HTTPClientError):
-    status_code = 403
-
-
-class HTTPNotFound(HTTPClientError):
-    status_code = 404
-
-
-class HTTPServerError(HTTPError):
-    """5xx responses."""
-
-
-class HTTPInternalServerError(HTTPServerError):
-    status_code = 500
-
-
-class HTTPBadGateway(HTTPServerError):
-    status_code = 503
-
-
-class HTTPGatewayTimeout(HTTPServerError):
-    status_code = 504
-
-
 def make_http_exception(response, message=None, swagger_result=None):
     """
     Return an HTTP exception class  based on the response. If a specific
@@ -103,3 +67,166 @@ def make_http_exception(response, message=None, swagger_result=None):
     """
     exc_class = status_map.get(response.status_code, HTTPError)
     return exc_class(response, message=message, swagger_result=swagger_result)
+
+
+class HTTPClientError(HTTPError):
+    """4xx responses."""
+
+
+class HTTPServerError(HTTPError):
+    """5xx responses."""
+
+
+# The follow are based on the HTTP Status Code Registery at
+# http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+
+class HTTPBadRequest(HTTPClientError):
+    status_code = 400
+
+
+class HTTPUnauthorized(HTTPClientError):
+    status_code = 401
+
+
+class HTTPPaymentRequired(HTTPClientError):
+    status_code = 402
+
+
+class HTTPForbidden(HTTPClientError):
+    status_code = 403
+
+
+class HTTPNotFound(HTTPClientError):
+    status_code = 404
+
+
+class HTTPMethodNotAllowed(HTTPClientError):
+    status_code = 405
+
+
+class HTTPNotAcceptable(HTTPClientError):
+    status_code = 406
+
+
+class HTTPProxyAuthenticationRequired(HTTPClientError):
+    status_code = 407
+
+
+class HTTPRequestTimeout(HTTPClientError):
+    status_code = 408
+
+
+class HTTPConflict(HTTPClientError):
+    status_code = 409
+
+
+class HTTPGone(HTTPClientError):
+    status_code = 410
+
+
+class HTTPLengthRequired(HTTPClientError):
+    status_code = 411
+
+
+class HTTPPreconditionFailed(HTTPClientError):
+    status_code = 412
+
+
+class HTTPPayloadTooLarge(HTTPClientError):
+    status_code = 413
+
+
+class HTTPURITooLong(HTTPClientError):
+    status_code = 414
+
+
+class HTTPUnsupportedMediaType(HTTPClientError):
+    status_code = 415
+
+
+class HTTPRangeNotSatisfiable(HTTPClientError):
+    status_code = 416
+
+
+class HTTPExpectationFailed(HTTPClientError):
+    status_code = 417
+
+
+class HTTPMisdirectedRequest(HTTPClientError):
+    status_code = 421
+
+
+class HTTPUnprocessableEntity(HTTPClientError):
+    status_code = 422
+
+
+class HTTPLocked(HTTPClientError):
+    status_code = 423
+
+
+class HTTPFailedDependency(HTTPClientError):
+    status_code = 424
+
+
+class HTTPUpgradeRequired(HTTPClientError):
+    status_code = 426
+
+
+class HTTPPreconditionRequired(HTTPClientError):
+    status_code = 428
+
+
+class HTTPTooManyRequests(HTTPClientError):
+    status_code = 429
+
+
+class HTTPRequestHeaderFieldsTooLarge(HTTPClientError):
+    status_code = 431
+
+
+class HTTPUnavailableForLegalReasons(HTTPClientError):
+    status_code = 451
+
+
+class HTTPInternalServerError(HTTPServerError):
+    status_code = 500
+
+
+class HTTPNotImplemented(HTTPServerError):
+    status_code = 501
+
+
+class HTTPBadGateway(HTTPServerError):
+    status_code = 502
+
+
+class HTTPServiceUnavailable(HTTPServerError):
+    status_code = 503
+
+
+class HTTPGatewayTimeout(HTTPServerError):
+    status_code = 504
+
+
+class HTTPHTTPVersionNotSupported(HTTPServerError):
+    status_code = 505
+
+
+class HTTPVariantAlsoNegotiates(HTTPServerError):
+    status_code = 506
+
+
+class HTTPInsufficientStorage(HTTPServerError):
+    status_code = 507
+
+
+class HTTPLoopDetected(HTTPServerError):
+    status_code = 508
+
+
+class HTTPNotExtended(HTTPServerError):
+    status_code = 510
+
+
+class HTTPNetworkAuthenticationRequired(HTTPServerError):
+    status_code = 511

--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -54,6 +54,10 @@ class HTTPBadRequest(HTTPClientError):
     status_code = 400
 
 
+class HTTPUnauthorized(HTTPClientError):
+    status_code = 401
+
+
 class HTTPForbidden(HTTPClientError):
     status_code = 403
 
@@ -68,6 +72,14 @@ class HTTPServerError(HTTPError):
 
 class HTTPInternalServerError(HTTPServerError):
     status_code = 500
+
+
+class HTTPBadGateway(HTTPServerError):
+    status_code = 503
+
+
+class HTTPGatewayTimeout(HTTPServerError):
+    status_code = 504
 
 
 def make_http_exception(response, message=None, swagger_result=None):

--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -2,14 +2,21 @@
 from six import with_metaclass
 
 
+# Dictionary of HTTP status codes to exception classes
 status_map = {}
 
 
 def _register_exception(exception_class):
+    """Store an HTTP exception class with a status code into a mapping
+    of status codes to exception classes.
+    :param exception_class: A subclass of HTTPError
+    :type exception_class: :class:`HTTPError`
+    """
     status_map[exception_class.status_code] = exception_class
 
 
 class HTTPErrorType(type):
+    """A metaclass for registering HTTPError subclasses."""
 
     def __new__(cls, *args, **kwargs):
         new_class = super(HTTPErrorType, cls).__new__(cls, *args, **kwargs)
@@ -84,11 +91,15 @@ class HTTPGatewayTimeout(HTTPServerError):
 
 def make_http_exception(response, message=None, swagger_result=None):
     """
+    Return an HTTP exception class  based on the response. If a specific
+    class doesn't exist for a particular HTTP status code, a more
+    general :class:`HTTPError` class will be returned.
     :type response: :class:`bravado_core.response.IncomingResponse`
     :param message: Optional string message
     :param swagger_result: If the response for this HTTPError is
         documented in the swagger spec, then this should be the result
         value of the response.
+    :return: An HTTP exception class that can be raised
     """
     exc_class = status_map.get(response.status_code, HTTPError)
     return exc_class(response, message=message, swagger_result=swagger_result)

--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -77,7 +77,7 @@ class HTTPServerError(HTTPError):
     """5xx responses."""
 
 
-# The follow are based on the HTTP Status Code Registery at
+# The follow are based on the HTTP Status Code Registry at
 # http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 
 class HTTPBadRequest(HTTPClientError):

--- a/tests/exception_test.py
+++ b/tests/exception_test.py
@@ -54,3 +54,13 @@ def test_make_http_exception(response_500):
     assert isinstance(exc, HTTPServerError)
     assert type(exc) == HTTPInternalServerError
     assert str(exc) == "500 Server Error: Holy moly!: {'msg': 'Kaboom'}"
+
+
+def test_make_http_exception_unknown():
+    requests_response = Response()
+    requests_response.status_code = 600
+    requests_response.reason = "Womp Error"
+    exc = make_http_exception(
+        RequestsResponseAdapter(requests_response),
+    )
+    assert type(exc) == HTTPError

--- a/tests/exception_test.py
+++ b/tests/exception_test.py
@@ -3,6 +3,9 @@ import pytest
 from requests.models import Response
 
 from bravado.exception import HTTPError
+from bravado.exception import make_http_exception
+from bravado.exception import HTTPInternalServerError
+from bravado.exception import HTTPServerError
 from bravado.requests_client import RequestsResponseAdapter
 
 
@@ -38,3 +41,16 @@ def test_response_and_message_and_swagger_result(response_500):
         message="Holy moly!",
         swagger_result={'msg': 'Kaboom'}))
     assert actual == "500 Server Error: Holy moly!: {'msg': 'Kaboom'}"
+
+
+def test_make_http_exception(response_500):
+    incoming_response = RequestsResponseAdapter(response_500)
+    exc = make_http_exception(
+        incoming_response,
+        message="Holy moly!",
+        swagger_result={'msg': 'Kaboom'}
+    )
+    assert isinstance(exc, HTTPError)
+    assert isinstance(exc, HTTPServerError)
+    assert type(exc) == HTTPInternalServerError
+    assert str(exc) == "500 Server Error: Holy moly!: {'msg': 'Kaboom'}"

--- a/tests/http_future/HttpFuture/result_test.py
+++ b/tests/http_future/HttpFuture/result_test.py
@@ -4,7 +4,8 @@ from bravado.http_future import FutureAdapter
 from mock import patch, Mock
 import pytest
 
-from bravado.http_future import HTTPError, HttpFuture
+from bravado.http_future import HttpFuture
+from bravado.exception import HTTPError
 
 
 def test_200_get_swagger_spec():


### PR DESCRIPTION
Add some common HTTP exception classes that inherit from HTTPError.
Added a common 4xx and 5xx error classes to start with.
fixes #252 