### PR TITLE
Contribution guidelines and master changelog

### DIFF
--- a/CHANGELOG-MASTER.rst
+++ b/CHANGELOG-MASTER.rst
@@ -1,0 +1,10 @@
+Changelog-Master
+================
+
+*This file will contain the Changelog of the master branch.*
+
+*The content will be used to build the Changelog of the new bravado release.*
+
+X.X.X (XXXX-XX-XX)
+------------------
+- PLACEHOLDER (add before this line your modifications summary)

--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,16 @@ Setup
     # Install git pre-commit hooks
     .tox/py27/bin/pre-commit install
 
+Contributing
+------------
+
+1. Fork it ( http://github.com/Yelp/bravado/fork )
+2. Create your feature branch (``git checkout -b my-new-feature``)
+3. Add your modifications
+4. Add short summary of your modifications on ``CHANGELOG-MASTER.rst``
+5. Commit your changes (``git commit -m "Add some feature"``)
+6. Push to the branch (``git push origin my-new-feature``)
+7. Create new Pull Request
 
 License
 -------


### PR DESCRIPTION
To target #255 could be helpful having a sort of guideline for the project contribution.

The ``CHANGELOG-MASTER.rst`` file is added in order to avoid to have the changelog related to the master modifications on [readthedocs](bravado.readthedocs.io/en/latest/changelog.html).