### PR TITLE
Remove Python 2.6, fixing a build failure; use Python 3.5 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 - TOX_ENV=docs
 - TOX_ENV=flake8
 install:
-- "pip install --use-mirrors tox coveralls"
+- "pip install tox coveralls"
 script:
 - tox -e $TOX_ENV
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: python
 env:
-- TOX_ENV=py26
 - TOX_ENV=py27
-- TOX_ENV=py34
+- TOX_ENV=py35
 - TOX_ENV=cover
 - TOX_ENV=docs
 - TOX_ENV=flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
+matrix:
+  include:
+  - python: "3.5"
+    env: TOX_ENV=py35
 env:
 - TOX_ENV=py27
-- TOX_ENV=py35
 - TOX_ENV=cover
 - TOX_ENV=docs
 - TOX_ENV=flake8

--- a/CHANGELOG-MASTER.rst
+++ b/CHANGELOG-MASTER.rst
@@ -7,4 +7,6 @@ Changelog-Master
 
 X.X.X (XXXX-XX-XX)
 ------------------
+- Remove support for Python 2.6, fixing build failure.
+- Switch from Python 3.4 to Python 3.5 for tests.
 - PLACEHOLDER (add before this line your modifications summary)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py34, flake8
+envlist = py27, py35, flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
This fixes #258.