### PR TITLE
Change getattr to just an attribute access (noop)

### DIFF
--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -40,7 +40,7 @@ class HTTPError(with_metaclass(HTTPErrorType, IOError)):
         self.response = response
         self.message = message
         self.swagger_result = swagger_result
-        self.status_code = getattr(self.response, 'status_code')
+        self.status_code = self.response.status_code
 
     def __str__(self):
         # Try to surface the most useful/relevant information available


### PR DESCRIPTION
2 arg getattr still raises so this is a noop (the intent of the original code is unclear -- maybe there's a bug?)

Accidentally commited this to master and reverted: 
- https://github.com/Yelp/bravado/commit/8b5ebe49e5232fde853503d0c4f23e74268bca3c
- https://github.com/Yelp/bravado/commit/d5a8b5c872f9dfd7b4ce5ee7c3f82e8da0316766