### PR TITLE
Api key header

### DIFF
--- a/CHANGELOG-MASTER.rst
+++ b/CHANGELOG-MASTER.rst
@@ -7,4 +7,5 @@ Changelog-Master
 
 X.X.X (XXXX-XX-XX)
 ------------------
+- Add API key authentication via header to RequestsClient
 - PLACEHOLDER (add before this line your modifications summary)

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,25 @@ Example with Basic Authentication
     )
     pet = client.pet.getPetById(petId=42).result()
 
+Example with Header Authentication
+---------------------------------
+
+.. code-block:: python
+
+    from bravado.requests_client import RequestsClient
+    from bravado.client import SwaggerClient
+    
+    http_client = RequestsClient()
+    http_client.set_api_key(
+        'api.yourhost.com', 'token'
+        param_name='api_key', param_in='header'
+    )
+    client = SwaggerClient.from_url(
+        'http://petstore.swagger.io/v2/swagger.json',
+        http_client=http_client,
+    )
+    pet = client.pet.getPetById(petId=42).result()
+
 Documentation
 -------------
 

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -48,20 +48,25 @@ class Authenticator(object):
 class ApiKeyAuthenticator(Authenticator):
     """?api_key authenticator.
 
-    This authenticator adds a query parameter to specify an API key.
+    This authenticator adds an API key via query parameter or header.
 
     :param host: Host to authenticate for.
     :param api_key: API key.
     :param param_name: Query parameter specifying the API key.
+    :param param_in: How to send the API key. Can be 'query' or 'header'.
     """
 
-    def __init__(self, host, api_key, param_name=u'api_key'):
+    def __init__(self, host, api_key, param_name=u'api_key', param_in=u'query'):
         super(ApiKeyAuthenticator, self).__init__(host)
         self.param_name = param_name
+        self.param_in = param_in
         self.api_key = api_key
 
     def apply(self, request):
-        request.params[self.param_name] = self.api_key
+        if self.param_in == 'header':
+            request.headers[self.param_name] = self.api_key
+        else:
+            request.params[self.param_name] = self.api_key
         return request
 
 
@@ -151,9 +156,9 @@ class RequestsClient(HttpClient):
         self.authenticator = BasicAuthenticator(
             host=host, username=username, password=password)
 
-    def set_api_key(self, host, api_key, param_name=u'api_key'):
+    def set_api_key(self, host, api_key, param_name=u'api_key', param_in=u'query'):
         self.authenticator = ApiKeyAuthenticator(
-            host=host, api_key=api_key, param_name=param_name)
+            host=host, api_key=api_key, param_name=param_name, param_in=param_in)
 
     def authenticated_request(self, request_params):
         return self.apply_authentication(requests.Request(**request_params))

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -112,6 +112,27 @@ class RequestsClientTestCase(unittest.TestCase):
         self.assertEqual('expected', resp.text)
         self.assertEqual({'foo': ['bar'], 'test': ['abc123']},
                          httpretty.last_request().querystring)
+        self.assertEqual(None, httpretty.last_request().headers.get('test'))
+
+    @httpretty.activate
+    def test_api_key_header(self):
+        httpretty.register_uri(
+            httpretty.GET, "http://swagger.py/client-test",
+            body='expected')
+
+        client = RequestsClient()
+        client.set_api_key("swagger.py", 'abc123', param_name='Key',
+                           param_in='header')
+        params = self._default_params()
+        params['params'] = {'foo': 'bar'}
+
+        resp = client.request(params).result()
+
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual('expected', resp.text)
+        self.assertEqual({'foo': ['bar']},
+                         httpretty.last_request().querystring)
+        self.assertEqual('abc123', httpretty.last_request().headers['Key'])
 
     @httpretty.activate
     def test_auth_leak(self):


### PR DESCRIPTION
I'm having a lot of success using bravado, but I find sending normal authentication headers annoying. You either have to send them with each request using _request_options or use a custom client which it isn't clear how to do from the docs. It feels to me like this is functionality that bravado should be shipping with, so I went ahead and added it.

This branch adds a 'param_in' argument to ApiKeyAuthenticator and RequestsClient.set_api_key that when sent with the value 'header' adds a header with the name of 'param_name'. I called this param_in to stay in the spirit of the 'in' field in swagger for api_key auth.

I'm not sure if there is already another way to do this that I missed, but if there is it is definitely not well documented.

Thanks!
