### PR TITLE
fix TypeError - requests.Request does not accept timeout arg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,13 +1,17 @@
+0.9.5 (2016-12-19)
+------------------
+- Fix TypeError bug when passing timeout in request_options
+
 0.9.4 (2016-11-17)
--------------------
+------------------
 - Fix Swaggerpy unicode bug for py3
 
 0.9.0 (2016-04-16)
--------------------
+------------------
 - Swaggerpy now py3 compatible.
 
 0.8.0 (2016-04-06)
--------------------
+------------------
 - Swaggerpy module importable under Py3. Tests for py3 needs more work.
 
 0.7.12 (2016-03-04)
@@ -21,7 +25,7 @@
 - Require twisted < 15.5.0 since Python 2.6 support was dropped.
 
 0.7.10 (2015-07-07)
-------------------
+-------------------
 - Make request and response available as attrs on HTTPError
 
 0.7.5 (2015-01-21)

--- a/swaggerpy/__init__.py
+++ b/swaggerpy/__init__.py
@@ -1,1 +1,1 @@
-version = '0.9.4'
+version = '0.9.5'

--- a/swaggerpy/swagger_model.py
+++ b/swaggerpy/swagger_model.py
@@ -20,6 +20,8 @@ SWAGGER_VERSIONS = [u"1.2"]
 
 log = logging.getLogger(__name__)
 
+# max timeout for swagger client initialization
+SWAGGER_INIT_TIMEOUT = 5
 
 # TODO: replace with swagger_schema_validator
 class ValidationProcessor(SwaggerProcessor):
@@ -170,7 +172,7 @@ def load_resource_listing(
         the http request to fetch resources.
     """
     request_options = request_options or {}
-    timeout = request_options.get('timeout', 5)
+    timeout = request_options.pop('timeout', SWAGGER_INIT_TIMEOUT)
     base_url = base_url or url
     processor = ValidationProcessor()
 

--- a/swaggerpy/swagger_model.py
+++ b/swaggerpy/swagger_model.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 # max timeout for swagger client initialization
 SWAGGER_INIT_TIMEOUT = 5
 
+
 # TODO: replace with swagger_schema_validator
 class ValidationProcessor(SwaggerProcessor):
     """A processor that validates the Swagger model.

--- a/tests/resource_listing_test.py
+++ b/tests/resource_listing_test.py
@@ -72,6 +72,21 @@ class ResourceListingTest(unittest.TestCase):
         [iterate_test(field) for field in ('swaggerVersion', 'apis')]
 
     @httpretty.activate
+    def test_request_options_timeout(self):
+        """We should be able to include a timeout for client initialization"""
+        self.register_urls()
+        httpretty.register_uri(
+            httpretty.GET, "http://localhost/api-docs/api",
+            body='{"swaggerVersion": "1.2", "basePath": "/", "apis":[]}')
+
+        SwaggerClient.from_url(
+            u'http://localhost/api-docs',
+            request_options={
+                'timeout': 15,
+            }
+        )
+
+    @httpretty.activate
     def test_success_with_api_call(self):
         self.register_urls()
         httpretty.register_uri(


### PR DESCRIPTION
There is a TypeError bug when setting a timeout on client creation.
The timeout option in request_options should only be used by swaggerpy as [it is not an argument](https://github.com/Yelp/bravado/blob/500bdae0f53b68fa24074ac7b447cc9508c0fe6e/swaggerpy/http_client.py#L176) of the requests.[Request](http://docs.python-requests.org/en/master/api/#requests.Request) object.

This will now be possible 

```python
SwaggerClient.from_url(
  u'http://localhost/api-docs',
  request_options={
    'timeout': 15,
  }
)
```