### PR TITLE
Fido as optional dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,16 @@
-
-- repo: git://github.com/pre-commit/pre-commit-hooks
-  sha: 5fe82b
-  hooks:
-    - id: autopep8-wrapper
-      args: ['-i', '--ignore=E309']
-    - id: check-json
-    - id: check-yaml
-    - id: debug-statements
-    - id: end-of-file-fixer
-    - id: flake8
-    - id: name-tests-test
-    - id: trailing-whitespace
-    - id: requirements-txt-fixer
-      files: 'requirements-dev.txt'
-
-# TODO: re-enable in bravado, disabled for now to avoid excessive merge
-# conflicts
-#- repo: git://github.com/FalconSocial/pre-commit-python-sorter
-#  sha: 1.0.1
-#  hooks:
-#    - id: python-import-sorter
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: v0.7.1
+    hooks:
+    -   id: autopep8-wrapper
+        args:
+        - -i
+        - --ignore=E309,E501
+    -   id: check-json
+    -   id: check-yaml
+    -   id: debug-statements
+    -   id: end-of-file-fixer
+    -   id: flake8
+    -   id: name-tests-test
+    -   id: trailing-whitespace
+    -   id: requirements-txt-fixer
+        files: requirements-dev.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@
         - --ignore=E309,E501
     -   id: check-json
     -   id: check-yaml
+    -   id: fix-encoding-pragma
     -   id: debug-statements
     -   id: end-of-file-fixer
     -   id: flake8
@@ -14,3 +15,7 @@
     -   id: trailing-whitespace
     -   id: requirements-txt-fixer
         files: requirements-dev.txt
+-   repo: git://github.com/asottile/reorder_python_imports
+    sha: v0.3.1
+    hooks:
+    -   id: reorder-python-imports

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,25 @@
 language: python
+
+python:
+- "2.7"
+- "3.5"
+env:
+- TOX_FLAVOR=default
+- TOX_FLAVOR=fido
+
 matrix:
   include:
-  - python: "3.5"
-    env: TOX_ENV=py35
-env:
-- TOX_ENV=py27
-- TOX_ENV=cover
-- TOX_ENV=docs
-- TOX_ENV=flake8
+  - python: "2.7"
+    env: TOX_ENV=cover
+  - python: "2.7"
+    env: TOX_ENV=docs
+  - python: "2.7"
+    env: TOX_ENV=flake8
+
 install:
 - "pip install tox coveralls"
 script:
-- tox -e $TOX_ENV
+- tox -e `if [ "x$TOX_ENV" == "x" ]; then echo py${TRAVIS_PYTHON_VERSION/./}-$TOX_FLAVOR; else echo $TOX_ENV; fi`
 after_success:
 - coveralls
 # Faster runs on container based infrastucture

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,17 @@ matrix:
   include:
   - env: TOXENV=py27-default
   - env: TOXENV=py27-fido
+
   - env: TOXENV=py35-default
-    python: python3.5
+    python: "3.5"
   - env: TOXENV=py35-fido
-    python: python3.5
+    python: "3.5"
+
+  - env: TOXENV=py36-default
+    python: "3.6"
+  - env: TOXENV=py36-fido
+    python: "3.6"
+
   - env: TOXENV=cover
   - env: TOXENV=docs
   - env: TOXENV=flake8
@@ -15,7 +22,7 @@ matrix:
 install:
 - "pip install tox coveralls"
 script:
-- tox -e $TOX_ENV
+- tox -e $TOXENV
 after_success:
 - coveralls
 # Faster runs on container based infrastucture

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,21 @@
 language: python
 
-python:
-- "2.7"
-- "3.5"
-env:
-- TOX_FLAVOR=default
-- TOX_FLAVOR=fido
-
 matrix:
   include:
-  - python: "2.7"
-    env: TOX_ENV=cover
-  - python: "2.7"
-    env: TOX_ENV=docs
-  - python: "2.7"
-    env: TOX_ENV=flake8
+  - env: TOXENV=py27-default
+  - env: TOXENV=py27-fido
+  - env: TOXENV=py35-default
+    python: python3.5
+  - env: TOXENV=py35-fido
+    python: python3.5
+  - env: TOXENV=cover
+  - env: TOXENV=docs
+  - env: TOXENV=flake8
 
 install:
 - "pip install tox coveralls"
 script:
-- tox -e `if [ "x$TOX_ENV" == "x" ]; then echo py${TRAVIS_PYTHON_VERSION/./}-$TOX_FLAVOR; else echo $TOX_ENV; fi`
+- tox -e $TOX_ENV
 after_success:
 - coveralls
 # Faster runs on container based infrastucture

--- a/CHANGELOG-MASTER.rst
+++ b/CHANGELOG-MASTER.rst
@@ -8,4 +8,5 @@ Changelog-Master
 X.X.X (XXXX-XX-XX)
 ------------------
 - Add API key authentication via header to RequestsClient
+- Fido client is an optional dependency. **NOTE**: if you intend to use bravado with fido client you need to install bravado with fido extras (``pip install bravado[fido]``)
 - PLACEHOLDER (add before this line your modifications summary)

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ however Bravado aims to be a complete replacement for code generation
 Example Usage
 -------------
 
-.. code:: Python
+.. code-block:: Python
 
     from bravado.client import SwaggerClient
     client = SwaggerClient.from_url('http://petstore.swagger.io/v2/swagger.json')
@@ -63,7 +63,7 @@ Example with Basic Authentication
     pet = client.pet.getPetById(petId=42).result()
 
 Example with Header Authentication
----------------------------------
+----------------------------------
 
 .. code-block:: python
 
@@ -81,6 +81,22 @@ Example with Header Authentication
     )
     pet = client.pet.getPetById(petId=42).result()
 
+Example with Fido Client (Async Http Client)
+--------------------------------------------
+
+.. code-block:: python
+
+    # Install bravado with fido extra (``pip install bravado[fido]``)
+    from bravado.fido_client import FidoClient
+    from bravado.client import SwaggerClient
+
+    http_client = FidoClient()
+    client = SwaggerClient.from_url(
+        'http://petstore.swagger.io/v2/swagger.json',
+        http_client=http_client,
+    )
+    pet = client.pet.getPetById(petId=42).result()
+
 Documentation
 -------------
 
@@ -89,9 +105,13 @@ More documentation is available at http://bravado.readthedocs.org
 Installation
 ------------
 
-::
+.. code-block:: bash
 
+    # To install bravado with Synchronous Http Client only.
     $ pip install bravado
+
+    # To install bravado with Synchronous and Asynchronous Http Client (RequestsClient and FidoClient).
+    $ pip install bravado[fido]
 
 Development
 ===========
@@ -104,10 +124,11 @@ recommended to keep dependencies and libraries isolated.
 Setup
 -----
 
-::
+.. code-block:: bash
 
     # Run tests
     tox
+
     # Install git pre-commit hooks
     tox -e pre-commit install
 

--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Setup
     # Run tests
     tox
     # Install git pre-commit hooks
-    .tox/py27/bin/pre-commit install
+    tox -e pre-commit install
 
 Contributing
 ------------

--- a/bravado/__init__.py
+++ b/bravado/__init__.py
@@ -1,1 +1,2 @@
+# -*- coding: utf-8 -*-
 version = '8.4.0'

--- a/bravado/client.py
+++ b/bravado/client.py
@@ -50,7 +50,8 @@ from bravado_core.exception import SwaggerMappingError
 from bravado_core.formatter import SwaggerFormat  # noqa
 from bravado_core.param import marshal_param
 from bravado_core.spec import Spec
-from six import iteritems, itervalues
+from six import iteritems
+from six import itervalues
 
 from bravado.docstring_property import docstring_property
 from bravado.requests_client import RequestsClient

--- a/bravado/client.py
+++ b/bravado/client.py
@@ -84,6 +84,7 @@ class SwaggerClient(object):
 
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     """
+
     def __init__(self, swagger_spec):
         self.swagger_spec = swagger_spec
 
@@ -220,6 +221,7 @@ class CallableOperation(object):
 
     :type operation: :class:`bravado_core.operation.Operation`
     """
+
     def __init__(self, operation):
         self.operation = operation
 

--- a/bravado/compat.py
+++ b/bravado/compat.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 
 try:
     import simplejson as json

--- a/bravado/docstring_property.py
+++ b/bravado/docstring_property.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Property decorator for the `__doc__` attribute.
 Useful for when you want a custom docstring for class instances
 while still showing a generic docstring for the class itself.

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -20,6 +20,7 @@ class FidoResponseAdapter(IncomingResponse):
 
     :type fido_response: :class:`fido.fido.Response`
     """
+
     def __init__(self, fido_response):
         self._delegate = fido_response
 

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -2,11 +2,11 @@
 import logging
 
 import crochet
-import requests
 import fido
+import requests
+from bravado_core.response import IncomingResponse
 from yelp_bytes import to_bytes
 
-from bravado_core.response import IncomingResponse
 from bravado.http_client import HttpClient
 from bravado.http_future import FutureAdapter
 from bravado.http_future import HttpFuture

--- a/bravado/http_client.py
+++ b/bravado/http_client.py
@@ -7,6 +7,7 @@ class HttpClient(object):
     """Interface for a minimal HTTP client that can retrieve Swagger specs
     and perform HTTP calls to fulfill a Swagger operation.
     """
+
     def request(self, request_params, operation=None, response_callbacks=None,
                 also_return_response=False):
         """

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -50,6 +50,7 @@ class HttpFuture(object):
         http response code, etc.
         Defaults to False for backwards compatibility.
     """
+
     def __init__(self, future, response_adapter, operation=None,
                  response_callbacks=None, also_return_response=False):
         self.future = future

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -2,8 +2,8 @@
 import sys
 
 import bravado_core
-from bravado_core.exception import MatchingResponseNotFound
 import six
+from bravado_core.exception import MatchingResponseNotFound
 
 from bravado.exception import make_http_exception
 

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from bravado_core.response import IncomingResponse
 import requests
 import requests.auth
+from bravado_core.response import IncomingResponse
 from six.moves.urllib import parse as urlparse
 
 from bravado.http_client import HttpClient

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -176,6 +176,7 @@ class RequestsResponseAdapter(IncomingResponse):
 
     :type requests_lib_response: :class:`requests.models.Response`
     """
+
     def __init__(self, requests_lib_response):
         self._delegate = requests_lib_response
 

--- a/bravado/swagger_model.py
+++ b/bravado/swagger_model.py
@@ -3,8 +3,8 @@ import contextlib
 import logging
 import os
 import os.path
-import yaml
 
+import yaml
 from bravado_core.spec import is_yaml
 from six.moves import urllib
 from six.moves.urllib import parse as urlparse

--- a/bravado/warning.py
+++ b/bravado/warning.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import warnings
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import sphinx_rtd_theme
 
 # -- General configuration -----------------------------------------------

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -61,13 +61,18 @@ Time to get Twisted! (Asynchronous client)
 
         client = SwaggerClient.from_url(
             'http://petstore.swagger.io/v2/swagger.json',
-            FidoClient())
+            FidoClient()
+        )
 
         result = client.pet.getPetById(petId=42).result(timeout=4)
 
 .. note::
 
         ``timeout`` parameter here is the timeout (in seconds) the call will block waiting for the complete response. The default timeout is to wait indefinitely.
+
+.. note::
+
+        To use Fido client you should install bravado with fido extra via ``pip install bravado[fido]``.
 
 This is too fancy for me! I want a simple dict response!
 --------------------------------------------------------
@@ -81,7 +86,8 @@ This is too fancy for me! I want a simple dict response!
 
         client = SwaggerClient.from_url(
             'http://petstore.swagger.io/v2/swagger.json',
-            config={'use_models': False})
+            config={'use_models': False}
+        )
 
         result = client.pet.getPetById(petId=42).result(timeout=4)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 # Unit test dependencies
 bottle
+ephemeral_port_reserve
 httpretty
 mock
 pre-commit

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
     install_requires=[
         "bravado-core >= 4.2.2",

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,12 @@ from setuptools import setup
 
 import bravado
 
+fido_client_dependencies = [
+    "crochet >= 1.4.0",
+    "fido >= 2.1.0",
+    "yelp_bytes",
+]
+
 setup(
     name="bravado",
     version=bravado.version,
@@ -25,22 +31,17 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",
     ],
     install_requires=[
         "bravado-core >= 4.2.2",
-        "crochet >= 1.4.0",
-        "fido >= 2.1.0",
-        "yelp_bytes",
         "python-dateutil",
         "pyyaml",
         "requests",
         "six",
     ],
     extras_require={
-        ':python_version=="2.6"': ['twisted >= 14.0.0, < 15.5'],
-        ':python_version!="2.6"': ['twisted >= 14.0.0'],
+        "fido": fido_client_dependencies,
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # Copyright (c) 2013, Digium, Inc.
 # Copyright (c) 2014-2016, Yelp, Inc.
-
 import os
 
 from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,6 @@ from setuptools import setup
 
 import bravado
 
-fido_client_dependencies = [
-    "crochet >= 1.4.0",
-    "fido >= 2.1.0",
-    "yelp_bytes",
-]
-
 setup(
     name="bravado",
     version=bravado.version,
@@ -42,6 +36,6 @@ setup(
         "six",
     ],
     extras_require={
-        "fido": fido_client_dependencies,
+        "fido": ["fido >= 2.1.0"],
     },
 )

--- a/tests/client/CallableOperation/docstring_test.py
+++ b/tests/client/CallableOperation/docstring_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from bravado_core.operation import Operation
 
 from bravado.client import CallableOperation

--- a/tests/client/ResourceDecorator/dir_test.py
+++ b/tests/client/ResourceDecorator/dir_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 def test_forwarded_to_delegate(petstore_client):
     expected = ['addPet', 'deletePet', 'findPetsByStatus', 'findPetsByTags',
                 'getPetById', 'updatePet', 'updatePetWithForm', 'uploadFile']

--- a/tests/client/SwaggerClient/getattr_test.py
+++ b/tests/client/SwaggerClient/getattr_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from bravado.client import ResourceDecorator

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -1,10 +1,11 @@
+# -*- coding: utf-8 -*-
 import os
 
-from bravado.compat import json
 import pytest
 
 from bravado.client import Spec
 from bravado.client import SwaggerClient
+from bravado.compat import json
 
 
 @pytest.fixture

--- a/tests/client/construct_params_test.py
+++ b/tests/client/construct_params_test.py
@@ -1,8 +1,8 @@
-from mock import patch
+# -*- coding: utf-8 -*-
 import pytest
-
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.operation import Operation
+from mock import patch
 
 from bravado.client import CallableOperation
 from bravado.client import construct_params

--- a/tests/client/construct_request_test.py
+++ b/tests/client/construct_request_test.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
+import pytest
 from bravado_core.operation import Operation
 from mock import patch
-import pytest
 
-from bravado.client import CallableOperation, construct_request
+from bravado.client import CallableOperation
+from bravado.client import construct_request
 
 
 @pytest.mark.parametrize('timeout_kv', [

--- a/tests/client/inject_headers_for_remote_refs_test.py
+++ b/tests/client/inject_headers_for_remote_refs_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from bravado_core.operation import Operation
 from mock import Mock
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -4,8 +4,8 @@ import tempfile
 import unittest
 
 import httpretty
-import requests
 import pytest
+import requests
 
 from bravado.client import SwaggerClient
 

--- a/tests/exception_test.py
+++ b/tests/exception_test.py
@@ -3,9 +3,9 @@ import pytest
 from requests.models import Response
 
 from bravado.exception import HTTPError
-from bravado.exception import make_http_exception
 from bravado.exception import HTTPInternalServerError
 from bravado.exception import HTTPServerError
+from bravado.exception import make_http_exception
 from bravado.requests_client import RequestsResponseAdapter
 
 

--- a/tests/fido_client/FidoClient/prepare_request_for_twisted_test.py
+++ b/tests/fido_client/FidoClient/prepare_request_for_twisted_test.py
@@ -4,7 +4,6 @@ Not Tested:
 1) Callbacks triggered by twisted and crochet
 2) Timeouts by crochet's wait()
 """
-
 from bravado.fido_client import FidoClient
 
 

--- a/tests/fido_client/FidoClient/request_test.py
+++ b/tests/fido_client/FidoClient/request_test.py
@@ -1,6 +1,6 @@
+# -*- coding: utf-8 -*-
 import mock
 from mock import patch
-
 
 from bravado.fido_client import FidoClient
 

--- a/tests/fido_client/FidoFutureAdapter/result_test.py
+++ b/tests/fido_client/FidoFutureAdapter/result_test.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-from mock import Mock
-import pytest
-
 import crochet
+import pytest
+from mock import Mock
 
 from bravado.fido_client import FidoFutureAdapter
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import functools
 import json
 

--- a/tests/functional/model_func_test.py
+++ b/tests/functional/model_func_test.py
@@ -1,14 +1,16 @@
+# -*- coding: utf-8 -*-
 """
 Functional tests related to passing models in req/response
 """
 import httpretty
 import pytest
-
 from jsonschema.exceptions import ValidationError
 
 from bravado.client import SwaggerClient
 from bravado.compat import json
-from tests.functional.conftest import register_spec, register_get, API_DOCS_URL
+from tests.functional.conftest import API_DOCS_URL
+from tests.functional.conftest import register_get
+from tests.functional.conftest import register_spec
 
 
 @pytest.fixture

--- a/tests/functional/request_func_test.py
+++ b/tests/functional/request_func_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Request related functional tests
 """
@@ -6,7 +7,9 @@ from six.moves import cStringIO
 from six.moves.urllib import parse as urlparse
 
 from bravado.client import SwaggerClient
-from tests.functional.conftest import register_spec, API_DOCS_URL, register_get
+from tests.functional.conftest import API_DOCS_URL
+from tests.functional.conftest import register_get
+from tests.functional.conftest import register_spec
 
 
 def test_form_params_in_request(httprettified, swagger_dict):

--- a/tests/functional/response_func_test.py
+++ b/tests/functional/response_func_test.py
@@ -1,16 +1,19 @@
+# -*- coding: utf-8 -*-
 """
 Response related functional tests
 """
 import datetime
 import functools
 
-from jsonschema.exceptions import ValidationError
 import pytest
+from jsonschema.exceptions import ValidationError
 
 from bravado.client import SwaggerClient
 from bravado.compat import json
 from bravado.exception import HTTPError
-from tests.functional.conftest import register_spec, register_get, API_DOCS_URL
+from tests.functional.conftest import API_DOCS_URL
+from tests.functional.conftest import register_get
+from tests.functional.conftest import register_spec
 
 
 register_test_http = functools.partial(

--- a/tests/functional/spec_func_test.py
+++ b/tests/functional/spec_func_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Swagger Specification related functional tests
 """
@@ -5,8 +6,11 @@ import httpretty
 import pytest
 from swagger_spec_validator.common import SwaggerValidationError
 
-from bravado.client import SwaggerClient, ResourceDecorator
-from tests.functional.conftest import register_get, register_spec, API_DOCS_URL
+from bravado.client import ResourceDecorator
+from bravado.client import SwaggerClient
+from tests.functional.conftest import API_DOCS_URL
+from tests.functional.conftest import register_get
+from tests.functional.conftest import register_spec
 
 
 def test_invalid_spec_raises_SwaggerValidationError(

--- a/tests/http_future/HttpFuture/result_test.py
+++ b/tests/http_future/HttpFuture/result_test.py
@@ -1,11 +1,13 @@
+# -*- coding: utf-8 -*-
+import pytest
 from bravado_core.operation import Operation
 from bravado_core.response import IncomingResponse
-from bravado.http_future import FutureAdapter
-from mock import patch, Mock
-import pytest
+from mock import Mock
+from mock import patch
 
-from bravado.http_future import HttpFuture
 from bravado.exception import HTTPError
+from bravado.http_future import FutureAdapter
+from bravado.http_future import HttpFuture
 
 
 def test_200_get_swagger_spec():

--- a/tests/http_future/raise_on_expected_test.py
+++ b/tests/http_future/raise_on_expected_test.py
@@ -1,6 +1,7 @@
+# -*- coding: utf-8 -*-
+import pytest
 from bravado_core.response import IncomingResponse
 from mock import Mock
-import pytest
 
 from bravado.exception import HTTPError
 from bravado.http_future import raise_on_expected

--- a/tests/http_future/raise_on_unexpected_test.py
+++ b/tests/http_future/raise_on_unexpected_test.py
@@ -1,6 +1,7 @@
+# -*- coding: utf-8 -*-
+import pytest
 from bravado_core.response import IncomingResponse
 from mock import Mock
-import pytest
 
 from bravado.exception import HTTPError
 from bravado.http_future import raise_on_unexpected

--- a/tests/http_future/unmarshall_response_test.py
+++ b/tests/http_future/unmarshall_response_test.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
 import pytest
-from mock import Mock, patch
 from bravado_core.exception import MatchingResponseNotFound
 from bravado_core.operation import Operation
 from bravado_core.response import IncomingResponse
+from mock import Mock
+from mock import patch
 
 from bravado.exception import HTTPError
 from bravado.http_future import unmarshal_response

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,15 +1,11 @@
 # -*- coding: utf-8 -*-
-
 import threading
 import time
 
-from six.moves import urllib
-
-
-import ephemeral_port_reserve
 import bottle
-
+import ephemeral_port_reserve
 import pytest
+from six.moves import urllib
 
 ROUTE_1_RESPONSE = b"HEY BUDDY"
 ROUTE_2_RESPONSE = b"BYE BUDDY"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+import socket
+import threading
+import time
+
+import bottle
+
+import pytest
+
+ROUTE_1_RESPONSE = b"HEY BUDDY"
+ROUTE_2_RESPONSE = b"BYE BUDDY"
+
+
+@bottle.route("/1")
+def one():
+    return ROUTE_1_RESPONSE
+
+
+@bottle.route("/2")
+def two():
+    return ROUTE_2_RESPONSE
+
+
+@bottle.post('/double')
+def double():
+    x = bottle.request.params['number']
+    return str(int(x) * 2)
+
+
+def get_hopefully_free_port():
+    s = socket.socket()
+    s.bind(('', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.yield_fixture(scope='session')
+def threaded_http_server():
+    port = get_hopefully_free_port()
+    thread = threading.Thread(
+        target=bottle.run, kwargs={'host': 'localhost', 'port': port},
+    )
+    thread.daemon = True
+    thread.start()
+    time.sleep(2)
+    yield port

--- a/tests/integration/fido_client_test.py
+++ b/tests/integration/fido_client_test.py
@@ -1,93 +1,14 @@
 # -*- coding: utf-8 -*-
-
-import socket
-import threading
-import time
-
-import bottle
-
 from bravado.fido_client import FidoClient
-
-ROUTE_1_RESPONSE = b"HEY BUDDY"
-ROUTE_2_RESPONSE = b"BYE BUDDY"
+from tests.integration.requests_client_test import TestServerRequestsClient
 
 
-@bottle.route("/1")
-def one():
-    return ROUTE_1_RESPONSE
-
-
-@bottle.route("/2")
-def two():
-    return ROUTE_2_RESPONSE
-
-
-@bottle.post('/double')
-def double():
-    x = bottle.request.params['number']
-    return str(int(x) * 2)
-
-
-def get_hopefully_free_port():
-    s = socket.socket()
-    s.bind(('', 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
-
-
-def launch_threaded_http_server(port):
-    thread = threading.Thread(
-        target=bottle.run, kwargs={'host': 'localhost', 'port': port},
-    )
-    thread.daemon = True
-    thread.start()
-    time.sleep(2)
-    return thread
-
-
-class TestServer():
+class TestServerFidoClient(TestServerRequestsClient):
 
     @classmethod
     def setup_class(cls):
-        cls.PORT = get_hopefully_free_port()
-        launch_threaded_http_server(cls.PORT)
-        cls.fido_client = FidoClient()
+        cls.http_client = FidoClient()
 
-    def test_multiple_requests_against_fido_client(self):
-
-        request_one_params = {
-            'method': 'GET',
-            'headers': {},
-            'url': "http://localhost:{0}/1".format(self.PORT),
-            'params': {},
-        }
-
-        request_two_params = {
-            'method': 'GET',
-            'headers': {},
-            'url': "http://localhost:{0}/2".format(self.PORT),
-            'params': {},
-        }
-
-        http_future_1 = self.fido_client.request(request_one_params)
-        http_future_2 = self.fido_client.request(request_two_params)
-        resp_one = http_future_1.result(timeout=1)
-        resp_two = http_future_2.result(timeout=1)
-
-        assert resp_one.text == ROUTE_1_RESPONSE
-        assert resp_two.text == ROUTE_2_RESPONSE
-
-    def test_post_request(self):
-
-        request_args = {
-            'method': 'POST',
-            'headers': {},
-            'url': "http://localhost:{0}/double".format(self.PORT),
-            'data': {"number": 3},
-        }
-
-        http_future = self.fido_client.request(request_args)
-        resp = http_future.result(timeout=1)
-
-        assert resp.text == b'6'
+    @classmethod
+    def encode_expected_response(cls, response):
+        return response

--- a/tests/integration/fido_client_test.py
+++ b/tests/integration/fido_client_test.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from bravado.fido_client import FidoClient
-from tests.integration.requests_client_test import TestServerRequestsClient
+from tests.integration import requests_client_test
 
 
-class TestServerFidoClient(TestServerRequestsClient):
+class TestServerFidoClient(requests_client_test.TestServerRequestsClient):
 
     @classmethod
     def setup_class(cls):

--- a/tests/integration/requests_client_test.py
+++ b/tests/integration/requests_client_test.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from bravado.requests_client import RequestsClient
+from tests.integration.conftest import ROUTE_1_RESPONSE
+from tests.integration.conftest import ROUTE_2_RESPONSE
+
+
+class TestServerRequestsClient:
+
+    @classmethod
+    def setup_class(cls):
+        cls.http_client = RequestsClient()
+
+    @classmethod
+    def encode_expected_response(cls, response):
+        if isinstance(response, bytes):
+            return response.decode('utf-8')
+        else:
+            return str(response)
+
+    def test_multiple_requests(self, threaded_http_server):
+
+        request_one_params = {
+            'method': 'GET',
+            'headers': {},
+            'url': "http://localhost:{0}/1".format(threaded_http_server),
+            'params': {},
+        }
+
+        request_two_params = {
+            'method': 'GET',
+            'headers': {},
+            'url': "http://localhost:{0}/2".format(threaded_http_server),
+            'params': {},
+        }
+
+        http_future_1 = self.http_client.request(request_one_params)
+        http_future_2 = self.http_client.request(request_two_params)
+        resp_one = http_future_1.result(timeout=1)
+        resp_two = http_future_2.result(timeout=1)
+
+        assert resp_one.text == self.encode_expected_response(ROUTE_1_RESPONSE)
+        assert resp_two.text == self.encode_expected_response(ROUTE_2_RESPONSE)
+
+    def test_post_request(self, threaded_http_server):
+
+        request_args = {
+            'method': 'POST',
+            'headers': {},
+            'url': "http://localhost:{0}/double".format(threaded_http_server),
+            'data': {"number": 3},
+        }
+
+        http_future = self.http_client.request(request_args)
+        resp = http_future.result(timeout=1)
+
+        assert resp.text == self.encode_expected_response(b'6')

--- a/tests/petstore/conftest.py
+++ b/tests/petstore/conftest.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from bravado.client import SwaggerClient

--- a/tests/petstore/pet/__init__.py
+++ b/tests/petstore/pet/__init__.py
@@ -1,1 +1,2 @@
+# -*- coding: utf-8 -*-
 __author__ = 'analogue'

--- a/tests/petstore/pet/addPet_test.py
+++ b/tests/petstore/pet/addPet_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 
 

--- a/tests/petstore/pet/deletePet_test.py
+++ b/tests/petstore/pet/deletePet_test.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
+
 import pytest
 
 

--- a/tests/petstore/pet/findPetsByStatus_test.py
+++ b/tests/petstore/pet/findPetsByStatus_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 def test_uses_default_of_available(petstore):
     status_code, pets = petstore.pet.findPetsByStatus().result()
     assert pets

--- a/tests/petstore/pet/findPetsByTags_test.py
+++ b/tests/petstore/pet/findPetsByTags_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 

--- a/tests/petstore/pet/getPetById_test.py
+++ b/tests/petstore/pet/getPetById_test.py
@@ -1,5 +1,8 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
+
 from pprint import pprint
+
 import pytest
 
 

--- a/tests/petstore/pet/updatePetWithForm_test.py
+++ b/tests/petstore/pet/updatePetWithForm_test.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
+
 import pytest
 
 

--- a/tests/petstore/pet/updatePet_test.py
+++ b/tests/petstore/pet/updatePet_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 

--- a/tests/petstore/pet/uploadFile_test.py
+++ b/tests/petstore/pet/uploadFile_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 
 

--- a/tests/petstore/store/__init__.py
+++ b/tests/petstore/store/__init__.py
@@ -1,1 +1,2 @@
+# -*- coding: utf-8 -*-
 __author__ = 'analogue'

--- a/tests/petstore/store/getInventory_test.py
+++ b/tests/petstore/store/getInventory_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 
 

--- a/tests/petstore/store/getOrderById_test.py
+++ b/tests/petstore/store/getOrderById_test.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
+
 import pytest
 
 

--- a/tests/petstore/store/placeOrder_test.py
+++ b/tests/petstore/store/placeOrder_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 

--- a/tests/petstore/user/creatUser_test.py
+++ b/tests/petstore/user/creatUser_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 def test_200_success(petstore):
     User = petstore.get_model('User')
     user = User(

--- a/tests/petstore/user/createUsersWithArrayInput_test.py
+++ b/tests/petstore/user/createUsersWithArrayInput_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 def test_200_success(petstore):
     User = petstore.get_model('User')
     users = [

--- a/tests/petstore/user/deleteUser_test.py
+++ b/tests/petstore/user/deleteUser_test.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
+
 import pytest
 
 

--- a/tests/petstore/user/getUserByName_test.py
+++ b/tests/petstore/user/getUserByName_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 

--- a/tests/petstore/user/loginUser_test.py
+++ b/tests/petstore/user/loginUser_test.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
+
 import pytest
 
 

--- a/tests/petstore/user/logoutUser_test.py
+++ b/tests/petstore/user/logoutUser_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 

--- a/tests/petstore/user/updateUser_test.py
+++ b/tests/petstore/user/updateUser_test.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
+
 import pytest
 
 

--- a/tests/requests_client/RequestsClient/separate_params_test.py
+++ b/tests/requests_client/RequestsClient/separate_params_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from bravado.requests_client import RequestsClient
 
 

--- a/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
+++ b/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from mock import Mock
 import pytest
+from mock import Mock
 from requests.sessions import Session
 
 from bravado.requests_client import RequestsFutureAdapter

--- a/tests/swagger_model/__init__.py
+++ b/tests/swagger_model/__init__.py
@@ -1,1 +1,2 @@
+# -*- coding: utf-8 -*-
 __author__ = 'spatel'

--- a/tests/swagger_model/load_file_test.py
+++ b/tests/swagger_model/load_file_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from bravado.swagger_model import load_file

--- a/tests/swagger_model/loader_test.py
+++ b/tests/swagger_model/loader_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from bravado.swagger_model import Loader

--- a/tests/warning/warn_for_deprecated_op_test.py
+++ b/tests/warning/warn_for_deprecated_op_test.py
@@ -1,4 +1,6 @@
-from mock import Mock, patch
+# -*- coding: utf-8 -*-
+from mock import Mock
+from mock import patch
 
 from bravado.client import CallableOperation
 from bravado.warning import warn_for_deprecated_op

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,15 @@
 [tox]
-envlist = py27, py35, flake8
+envlist = {py27,py35}-{default,fido}, flake8
 
 [testenv]
 deps =
     -rrequirements-dev.txt
+extras =
+    fido: fido
+setenv =
+    default: PYTEST_ADDOPTS=--ignore=tests/fido_client --ignore=tests/integration/fido_client_test.py
 commands =
-    py.test --capture=no {posargs:tests}
+    python -m pytest --capture=no {posargs:tests}
 
 [testenv:flake8]
 basepython = python2.7
@@ -13,10 +17,16 @@ deps = flake8
 commands =
     flake8 bravado tests
 
+[testenv:pre-commit]
+deps = pre-commit>=0.12.0
+commands = pre-commit {posargs}
+
 [testenv:cover]
 deps =
     {[testenv]deps}
     coverage
+extras =
+    fido
 commands =
     coverage run --source=bravado/ --omit=bravado/__about__.py -m pytest --capture=no --strict {posargs:tests/}
     coverage report --omit=.tox/*,tests/*,/usr/share/pyshared/*,/usr/lib/pymodules/* -m

--- a/tox.ini
+++ b/tox.ini
@@ -42,8 +42,6 @@ commands = sphinx-build -b html -d build/doctrees source build/html
 [flake8]
 exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,docs,virtualenv_run
 max_line_length = 120
-# Workaround for bravado/fido_client.py:9:1: E402 module level import not at top of file
-ignore = E402
 
 [pytest]
 # tests/petstore/* are temporary and hit the swagger pet store directly.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35}-{default,fido}, flake8
+envlist = {py27,py35,py36}-{default,fido}, flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR is a suggestion for issue #227.

The idea is to provide by default bravado without dependencies for fido client and installing all the dependencies only if explicitly required.

``pip install bravado`` will not install ``fido`` related dependencies, while ``pip install bravado[fido]`` will install them.

Unfortunately it is not possible, at least with the current implementation, to make bravado with fido independent from requests because of [this block](https://github.com/Yelp/bravado/blob/2e7edec76517386582ce111d48c5489dba73efa2/bravado/fido_client.py#L100-L113).

To avoid skipping all the integration tests in case of packaging without fido I have have mirrored ``fido_client_test.py`` to ``requests_client_test.py``.

Suggestions and improvements will be appreciated.

PS. I have removed python2.6 definitions from setup.py because we dropped support in 8.4.0 (September 2016).