### PR TITLE
Fix test failures caused by swagger-spec-validator 2.0.3

### DIFF
--- a/tests/functional/request_func_test.py
+++ b/tests/functional/request_func_test.py
@@ -14,20 +14,20 @@ from tests.functional.conftest import register_spec
 
 def test_form_params_in_request(httprettified, swagger_dict):
     param1_spec = {
-        "in": "formData",
-        "name": "param_id",
-        "type": "integer"
+        'in': 'formData',
+        'name': 'param_id',
+        'type': 'integer'
     }
     param2_spec = {
-        "in": "formData",
-        "name": "param_name",
-        "type": "string"
+        'in': 'formData',
+        'name': 'param_name',
+        'type': 'string'
     }
     path_spec = swagger_dict['paths']['/test_http']
     path_spec['post'] = path_spec.pop('get')
     path_spec['post']['parameters'] = [param1_spec, param2_spec]
     register_spec(swagger_dict)
-    httpretty.register_uri(httpretty.POST, "http://localhost/test_http?")
+    httpretty.register_uri(httpretty.POST, 'http://localhost/test_http?')
     resource = SwaggerClient.from_url(API_DOCS_URL).api_test
     resource.testHTTP(param_id=42, param_name='foo').result()
     content_type = httpretty.last_request().headers['content-type']
@@ -38,35 +38,36 @@ def test_form_params_in_request(httprettified, swagger_dict):
 
 def test_file_upload_in_request(httprettified, swagger_dict):
     param1_spec = {
-        "in": "formData",
-        "name": "param_id",
-        "type": "integer"
+        'in': 'formData',
+        'name': 'param_id',
+        'type': 'integer'
     }
     param2_spec = {
-        "in": "formData",
-        "name": "file_name",
-        "type": "file"
+        'in': 'formData',
+        'name': 'file_name',
+        'type': 'file'
     }
     path_spec = swagger_dict['paths']['/test_http']
     path_spec['post'] = path_spec.pop('get')
     path_spec['post']['parameters'] = [param1_spec, param2_spec]
     path_spec['post']['consumes'] = ['multipart/form-data']
     register_spec(swagger_dict)
-    httpretty.register_uri(httpretty.POST, "http://localhost/test_http?")
+    httpretty.register_uri(httpretty.POST, 'http://localhost/test_http?')
     resource = SwaggerClient.from_url(API_DOCS_URL).api_test
     resource.testHTTP(param_id=42, file_name=cStringIO('boo')).result()
     content_type = httpretty.last_request().headers['content-type']
 
     assert content_type.startswith('multipart/form-data')
-    assert b"42" in httpretty.last_request().body
-    assert b"boo" in httpretty.last_request().body
+    assert b'42' in httpretty.last_request().body
+    assert b'boo' in httpretty.last_request().body
 
 
 def test_parameter_in_path_of_request(httprettified, swagger_dict):
     path_param_spec = {
-        "in": "path",
-        "name": "param_id",
-        "type": "string"
+        'in': 'path',
+        'name': 'param_id',
+        'required': True,
+        'type': 'string',
     }
     paths_spec = swagger_dict['paths']
     paths_spec['/test_http/{param_id}'] = paths_spec.pop('/test_http')
@@ -75,7 +76,7 @@ def test_parameter_in_path_of_request(httprettified, swagger_dict):
     register_spec(swagger_dict)
     register_get('http://localhost/test_http/42?test_param=foo')
     resource = SwaggerClient.from_url(API_DOCS_URL).api_test
-    assert resource.testHTTP(test_param="foo", param_id="42").result() is None
+    assert resource.testHTTP(test_param='foo', param_id='42').result() is None
 
 
 def test_default_value_not_in_request(httprettified, swagger_dict):
@@ -83,7 +84,7 @@ def test_default_value_not_in_request(httprettified, swagger_dict):
     # the request.
     swagger_dict['paths']['/test_http']['get']['parameters'][0]['default'] = 'X'
     register_spec(swagger_dict)
-    register_get("http://localhost/test_http?")
+    register_get('http://localhost/test_http?')
     resource = SwaggerClient.from_url(API_DOCS_URL).api_test
     resource.testHTTP().result()
     assert 'test_param' not in httpretty.last_request().querystring
@@ -99,6 +100,7 @@ def test_array_with_collection_format_in_path_of_request(
             'type': 'integer'
         },
         'collectionFormat': 'csv',
+        'required': True,
     }
     swagger_dict['paths']['/test_http/{param_ids}'] = \
         swagger_dict['paths'].pop('/test_http')


### PR DESCRIPTION
swagger-spec-validator ships with an updated Swagger 2.0 schema, which
causes two tests two fail since the 'required' field is missing from the
param definition in those tests. This fixes our internal build failure.

I've also made string quotes consistent in that file.