### PR TITLE
Fix build if using older tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@ envlist = {py27,py35,py36}-{default,fido}, flake8
 [testenv]
 deps =
     -rrequirements-dev.txt
-extras =
-    fido: fido
+    fido: .[fido]
 setenv =
     default: PYTEST_ADDOPTS=--ignore=tests/fido_client --ignore=tests/integration/fido_client_test.py
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ commands =
     python -m pytest --capture=no {posargs:tests}
 
 [testenv:flake8]
+skip_install = True
 basepython = python2.7
 deps = flake8
 commands =
@@ -22,17 +23,16 @@ commands = pre-commit {posargs}
 
 [testenv:cover]
 deps =
-    {[testenv]deps}
+    -rrequirements-dev.txt
+    .[fido]
     coverage
-extras =
-    fido
 commands =
     coverage run --source=bravado/ --omit=bravado/__about__.py -m pytest --capture=no --strict {posargs:tests/}
     coverage report --omit=.tox/*,tests/*,/usr/share/pyshared/*,/usr/lib/pymodules/* -m
 
 [testenv:docs]
+skip_install = True
 deps =
-    {[testenv]deps}
     sphinx
     sphinx-rtd-theme
 changedir = docs


### PR DESCRIPTION
Older tox versions don't know about `extras`, let's use a different way to install them.