### PR TITLE
Injected headers are casted to strings

### DIFF
--- a/bravado/client.py
+++ b/bravado/client.py
@@ -283,7 +283,9 @@ def construct_request(operation, request_options, **op_kwargs):
         'method': str(operation.http_method.upper()),
         'url': url,
         'params': {},  # filled in downstream
-        'headers': request_options.get('headers', {}),
+        # Ensure that headers injected via request_options are converted to string
+        # This is need to workaround https://github.com/requests/requests/issues/3491
+        'headers': {k: str(v) for k, v in iteritems(request_options.get('headers', {}))},
     }
 
     # Copy over optional request options

--- a/tests/client/construct_request_test.py
+++ b/tests/client/construct_request_test.py
@@ -12,12 +12,32 @@ from bravado.client import construct_request
     ('connect_timeout', 2),
 ])
 @patch('bravado.client.marshal_param')
-def test_with_timeouts(mock_marshal_param, minimal_swagger_spec,
-                       getPetById_spec, request_dict, timeout_kv):
+def test_with_timeouts(
+    mock_marshal_param, minimal_swagger_spec,
+    getPetById_spec, request_dict, timeout_kv,
+):
     request_dict['url'] = '/pet/{petId}'
     op = CallableOperation(Operation.from_spec(
         minimal_swagger_spec, '/pet/{petId}', 'get', getPetById_spec))
     k, v = timeout_kv
     request = construct_request(op, request_options={k: v}, petId=34, api_key='foo')
     assert request[k] == v
+    assert mock_marshal_param.call_count == 2
+
+
+@pytest.mark.parametrize('header_name, header_value', [
+    ('boolean', True),
+    ('integer', 1),
+    ('float', 2.0),
+])
+@patch('bravado.client.marshal_param')
+def test_with_not_string_headers(
+    mock_marshal_param, minimal_swagger_spec,
+    getPetById_spec, request_dict, header_name, header_value,
+):
+    request_dict['url'] = '/pet/{petId}'
+    op = CallableOperation(Operation.from_spec(
+        minimal_swagger_spec, '/pet/{petId}', 'get', getPetById_spec))
+    request = construct_request(op, request_options={'headers': {header_name: header_value}}, petId=34, api_key='foo')
+    assert request['headers'][header_name] == str(header_value)
     assert mock_marshal_param.call_count == 2


### PR DESCRIPTION
As done in [bravado-core PR #115](https://github.com/Yelp/bravado-core/pull/115) we should cast headers injected via ``_request_options`` to string.
This is a workaround for [requests issue #3491](https://github.com/requests/requests/issues/3491). More context on bravado-core PR