### PR TITLE
[SwaggerPy] Injected headers are casted to strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
-env:
-- TOXENV=py26
-- TOXENV=py27
-- TOXENV=py34
-- TOXENV=cover
-- TOXENV=docs
-- TOXENV=flake8
+matrix:
+  include:
+    - env: TOXENV=py26
+      python: "2.6"
+    - env: TOXENV=py27
+    - env: TOXENV=py34
+    - env: TOXENV=cover
+    - env: TOXENV=docs
+    - env: TOXENV=flake8
 install:
 - pip install tox coveralls
 script:

--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -179,6 +179,15 @@ class Operation(object):
     def _construct_request(self, **kwargs):
         _request_options = kwargs.pop('_request_options', {}) or {}
 
+        if 'headers' in _request_options:
+            # Ensure that headers injected via request_options are converted
+            # to string. This is need to workaround
+            # https://github.com/requests/requests/issues/3491
+            _request_options['headers'] = dict(
+                (k, str(v))
+                for k, v in six.iteritems(_request_options['headers'])
+            )
+
         request = {}
         # The requests library expects native strings. Without this, POST
         # with a binary file upload throws a UnicodeDecodeError.

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -167,10 +167,12 @@ class ClientTest(unittest.TestCase):
         self.uut = SwaggerClient.from_resource_listing(self.resource_listing)
         httpretty.register_uri(
             httpretty.GET, "http://swagger.py/swagger-test/pet",
-            body='[]')
+            body='[]',
+        )
 
         self.uut.pet.listPets(
-            _request_options={'headers': {'foo': 'bar'}}).result()
+            _request_options={'headers': {'foo': 'bar'}},
+        ).result()
         self.assertEqual('bar', httpretty.last_request().headers['foo'])
 
     @httpretty.activate
@@ -180,11 +182,22 @@ class ClientTest(unittest.TestCase):
             httpretty.GET, "http://swagger.py/swagger-test/pet",
             body='[]')
 
+        headers = {
+            'string': 'string',
+            'boolean': False,
+            'integer': 1,
+            'float': 2.0,
+        }
+
         self.uut.pet.listPets(
-            _request_options={'headers': {'foo': 'bar', 'sweet': 'bike'}},
+            _request_options={'headers': headers},
         ).result()
-        self.assertEqual('bar', httpretty.last_request().headers['foo'])
-        self.assertEqual('bike', httpretty.last_request().headers['sweet'])
+
+        for name, value in headers.items():
+            self.assertEqual(
+                str(value),
+                httpretty.last_request().headers[name],
+            )
 
     @httpretty.activate
     def test_get(self):
@@ -260,8 +273,9 @@ class ClientTest(unittest.TestCase):
 
     def test_unicode_method(self):
         self.assertEqual(
-                self.uut.pet.listPets._construct_request()['method'],
-                'GET')
+            self.uut.pet.listPets._construct_request()['method'],
+            'GET',
+        )
 
     def setUp(self):
         # Default handlers for all swagger.py access

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,7 @@ deps =
     {[testenv]deps}
     pytest-cov
 commands =
-    py.test --cov swaggerpy {posargs:tests}
-    coverage combine --append
+    coverage run --source=swaggerpy/ -m pytest --capture=no --strict {posargs:tests/}
     coverage report --omit=.tox/*,tests/*,/usr/share/pyshared/*,/usr/lib/pymodules/* -m
 
 [testenv:docs]


### PR DESCRIPTION
Context on #288  (same change from Swagger 2.0 client)

@sjaensch could we even release this new version ?