### PR TITLE
Make sure we throw the correct timeout exception when using the fido client

### DIFF
--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -3,6 +3,7 @@ import logging
 
 import crochet
 import fido
+import fido.exceptions
 import requests
 from bravado_core.response import IncomingResponse
 from yelp_bytes import to_bytes
@@ -148,4 +149,8 @@ class FidoFutureAdapter(FutureAdapter):
             return self._eventual_result.wait(timeout=timeout)
         except crochet.TimeoutError:
             self._eventual_result.cancel()
-            raise
+            raise fido.exceptions.HTTPTimeoutError(
+                'Connection was closed by fido after blocking for '
+                'timeout={timeout} seconds waiting for the server to '
+                'send the response'.format(timeout=timeout)
+            )

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 import logging
+import sys
 
 import crochet
 import fido
 import fido.exceptions
 import requests
+import six
 from bravado_core.response import IncomingResponse
 from yelp_bytes import to_bytes
 
@@ -149,8 +151,12 @@ class FidoFutureAdapter(FutureAdapter):
             return self._eventual_result.wait(timeout=timeout)
         except crochet.TimeoutError:
             self._eventual_result.cancel()
-            raise fido.exceptions.HTTPTimeoutError(
-                'Connection was closed by fido after blocking for '
-                'timeout={timeout} seconds waiting for the server to '
-                'send the response'.format(timeout=timeout)
+            six.reraise(
+                fido.exceptions.HTTPTimeoutError,
+                fido.exceptions.HTTPTimeoutError(
+                    'Connection was closed by fido after blocking for '
+                    'timeout={timeout} seconds waiting for the server to '
+                    'send the response'.format(timeout=timeout)
+                ),
+                sys.exc_info()[2],
             )

--- a/tests/fido_client/FidoFutureAdapter/result_test.py
+++ b/tests/fido_client/FidoFutureAdapter/result_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import crochet
+import fido.exceptions
 import pytest
 from mock import Mock
 
@@ -18,7 +19,8 @@ def test_eventual_result_cancelled_on_exception():
     mock_eventual_result = Mock(wait=Mock(side_effect=crochet.TimeoutError()))
     adapter = FidoFutureAdapter(mock_eventual_result)
 
-    with pytest.raises(crochet.TimeoutError):
-        adapter.result()
+    with pytest.raises(fido.exceptions.HTTPTimeoutError) as exc_info:
+        adapter.result(timeout=1)
 
     assert mock_eventual_result.cancel.called is True
+    assert str(exc_info.value).startswith('Connection was closed by fido after blocking for timeout=1 seconds')


### PR DESCRIPTION
You can pass two timeout values to bravado: One as part of the _request_options parameter when creating a future, and another one when calling result(). The timeout triggered by the _request_options parameter is handled by fido internally - it's a twisted timeout error.

The call to result() with a timeout parameter is unfortunately converted to a a crochet.TimeoutError  by crochet's eventloop ([here](https://github.com/itamarst/crochet/blob/8bba614f9f3d64c3741a43f48607e8ff6c5b50a1/crochet/_eventloop.py#L192)). Let's make sure we convert that exception to a fido HTTPTimeoutError for consistency. It's also what our internal retry mechanism expects.