### PR TITLE
Fix regression introduced by PR #288

### DIFF
--- a/bravado/client.py
+++ b/bravado/client.py
@@ -283,9 +283,7 @@ def construct_request(operation, request_options, **op_kwargs):
         'method': str(operation.http_method.upper()),
         'url': url,
         'params': {},  # filled in downstream
-        # Ensure that headers injected via request_options are converted to string
-        # This is need to workaround https://github.com/requests/requests/issues/3491
-        'headers': {k: str(v) for k, v in iteritems(request_options.get('headers', {}))},
+        'headers': request_options.get('headers', {}),
     }
 
     # Copy over optional request options
@@ -294,6 +292,13 @@ def construct_request(operation, request_options, **op_kwargs):
             request[request_option] = request_options[request_option]
 
     construct_params(operation, request, op_kwargs)
+
+    # Ensure that all the headers are converted to strings.
+    # This is need to workaround https://github.com/requests/requests/issues/3491
+    request['headers'] = {
+        k: str(v)
+        for k, v in iteritems(request['headers'])
+    }
     return request
 
 

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -35,7 +35,7 @@ def getPetById_spec(petstore_dict):
 
 
 @pytest.fixture
-def minimal_swagger_spec(getPetById_spec):
+def minimal_swagger_dict(getPetById_spec):
     spec_dict = {
         'paths': {
             '/pet/{petId}': {
@@ -50,6 +50,11 @@ def minimal_swagger_spec(getPetById_spec):
             },
         },
     }
-    spec = Spec(spec_dict)
-    spec.api_url = 'http://localhost/swagger.json'
+    return spec_dict
+
+
+@pytest.fixture
+def minimal_swagger_spec(minimal_swagger_dict):
+    spec = Spec(minimal_swagger_dict)
+    spec.api_url = 'http://localhost/'
     return spec

--- a/tests/client/construct_request_test.py
+++ b/tests/client/construct_request_test.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 import pytest
 from bravado_core.operation import Operation
+from bravado_core.request import IncomingRequest
+from bravado_core.request import unmarshal_request
+from mock import mock
 from mock import patch
 
 from bravado.client import CallableOperation
 from bravado.client import construct_request
+from tests.client.conftest import minimal_swagger_spec as build_swagger_spec
 
 
 @pytest.mark.parametrize('timeout_kv', [
@@ -25,19 +29,57 @@ def test_with_timeouts(
     assert mock_marshal_param.call_count == 2
 
 
-@pytest.mark.parametrize('header_name, header_value', [
-    ('boolean', True),
-    ('integer', 1),
-    ('float', 2.0),
-])
-@patch('bravado.client.marshal_param')
+@pytest.mark.parametrize(
+    'swagger_type, swagger_format, header_name, header_value', [
+        ('boolean', None, 'boolean', True),
+        ('integer', None, 'integer', 1),
+        ('number', 'float', 'float', 2.0),
+    ],
+)
 def test_with_not_string_headers(
-    mock_marshal_param, minimal_swagger_spec,
-    getPetById_spec, request_dict, header_name, header_value,
+    minimal_swagger_dict, getPetById_spec, request_dict,
+    swagger_type, swagger_format, header_name, header_value,
 ):
-    request_dict['url'] = '/pet/{petId}'
-    op = CallableOperation(Operation.from_spec(
-        minimal_swagger_spec, '/pet/{petId}', 'get', getPetById_spec))
-    request = construct_request(op, request_options={'headers': {header_name: header_value}}, petId=34, api_key='foo')
+    url = '/pet/{petId}'
+    parameter = {
+        'name': header_name,
+        'in': 'header',
+        'required': False,
+        'type': swagger_type,
+    }
+    if swagger_format:
+        parameter['format'] = swagger_format
+    minimal_swagger_dict['paths'][url]['get']['parameters'].append(parameter)
+
+    minimal_swagger_spec = build_swagger_spec(minimal_swagger_dict)
+    request_dict['url'] = url
+
+    operation = Operation.from_spec(
+        swagger_spec=minimal_swagger_spec,
+        path_name='/pet/{petId}',
+        http_method='get',
+        op_spec=getPetById_spec,
+    )
+
+    petId = 34
+    api_key = 'foo'
+    request = construct_request(
+        operation=operation,
+        request_options={'headers': {header_name: header_value}},
+        petId=petId,
+        api_key=api_key,
+    )
+
+    # To unmarshall a request bravado-core needs the request to be wrapped
+    # by an object with a specific list of attributes
+    request_object = type('IncomingRequest', (IncomingRequest,), {
+        'path': {'petId': petId},
+        'query': {},
+        'form': {},
+        'headers': request['headers'],
+        'files': mock.Mock(),
+    })
+
     assert request['headers'][header_name] == str(header_value)
-    assert mock_marshal_param.call_count == 2
+    unmarshalled_request = unmarshal_request(request_object, operation)
+    assert unmarshalled_request[header_name] == header_value


### PR DESCRIPTION
@sjaensch highlighted in #288 that we're converting headers to strings too soon.
In order to reproduce the error we should:
 * use an endpoint that defines a non string header parameter
 * inject header parameter via ``_request_options`` instead of via ``kwargs`` on ``Operation`` object

Example:
Let's assume that we have an endpoint which defines an header parameter of type ``integer`` named ``parameter``. The endpoint is accessible via ``client.tag.endpoint``.
```python
k = client.tag.endpoint(parameter=1).result()
r = client.tag.endpoint(_request_options={'headers': {'parameter': 1}}).result()
```
``k`` and ``r`` should produce an equivalent HTTP request and so an equivalent result.
This is valid with ``bravado<9.0.2``, but not valid anymore with ``bravado==9.0.2``.

This is caused by the fact that ``bravado-core`` will validate the headers during [``marshal_param``](https://github.com/Yelp/bravado/compare/master...macisamuele:fix-regression-stringify-headers#diff-b7921701c1024606d23a5ebb67b3a930R328), but the header has already been converted to string and so the validation will fail.

The solution for this regression is to postpone the headers conversion to string after ``bravado-core`` as terminated to build the request (so just before the ``return`` statement)