### PR TITLE
Move headers conversion as late as possible in the HTTP stack

### DIFF
--- a/bravado/client.py
+++ b/bravado/client.py
@@ -293,12 +293,6 @@ def construct_request(operation, request_options, **op_kwargs):
 
     construct_params(operation, request, op_kwargs)
 
-    # Ensure that all the headers are converted to strings.
-    # This is need to workaround https://github.com/requests/requests/issues/3491
-    request['headers'] = {
-        k: str(v)
-        for k, v in iteritems(request['headers'])
-    }
     return request
 
 

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -102,6 +102,14 @@ class FidoClient(HttpClient):
         """
 
         prepared_request = requests.PreparedRequest()
+
+        # Ensure that all the headers are converted to strings.
+        # This is need to workaround https://github.com/requests/requests/issues/3491
+        request_params['headers'] = {
+            k: str(v)
+            for k, v in six.iteritems(request_params.get('headers', {}))
+        }
+
         prepared_request.prepare(
             headers=request_params.get('headers'),
             data=request_params.get('data'),

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -1,19 +1,8 @@
 # -*- coding: utf-8 -*-
-import os
-
 import pytest
 
 from bravado.client import Spec
 from bravado.client import SwaggerClient
-from bravado.compat import json
-
-
-@pytest.fixture
-def petstore_dict():
-    my_dir = os.path.abspath(os.path.dirname(__file__))
-    fpath = os.path.join(my_dir, '../../test-data/2.0/petstore/swagger.json')
-    with open(fpath) as f:
-        return json.loads(f.read())
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+
+import pytest
+
+
+@pytest.fixture
+def test_dir():
+    return os.path.abspath(os.path.dirname(__file__))
+
+
+@pytest.fixture
+def petstore_dict(test_dir):
+    fpath = os.path.join(test_dir, '../test-data/2.0/petstore/swagger.json')
+    with open(fpath) as f:
+        return json.loads(f.read())

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 import threading
 import time
 
@@ -7,8 +8,16 @@ import ephemeral_port_reserve
 import pytest
 from six.moves import urllib
 
+from tests.conftest import petstore_dict
+from tests.conftest import test_dir
+
 ROUTE_1_RESPONSE = b"HEY BUDDY"
 ROUTE_2_RESPONSE = b"BYE BUDDY"
+
+
+@bottle.get("/swagger.json")
+def swagger_spec():
+    return json.dumps(petstore_dict(test_dir()))
 
 
 @bottle.route("/1")


### PR DESCRIPTION
Moving header conversion to string down on the HTTP request pipeline.
It is moved just before preparing the HTTP request via ``requests`` library.

It was made needed because ``bravado==9.0.4`` was caring about string conversion for HTTP requests originated by endpoint, without considering that even HTTP requests for loading specs could inject non-string headers in the request.

In order to ensure correctness I have added two integration tests:
- ``test_fetch_specs``
-  ``test_boolean_header``