### PR TITLE
Prevent bytestring header values from being mangled

### DIFF
--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -106,7 +106,7 @@ class FidoClient(HttpClient):
         # Ensure that all the headers are converted to strings.
         # This is need to workaround https://github.com/requests/requests/issues/3491
         request_params['headers'] = {
-            k: str(v)
+            k: v if isinstance(v, six.binary_type) else str(v)
             for k, v in six.iteritems(request_params.get('headers', {}))
         }
 

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -3,6 +3,7 @@ import logging
 
 import requests
 import requests.auth
+import six
 from bravado_core.response import IncomingResponse
 from six import iteritems
 from six.moves.urllib import parse as urlparse
@@ -278,7 +279,7 @@ class RequestsFutureAdapter(FutureAdapter):
         # Ensure that all the headers are converted to strings.
         # This is need to workaround https://github.com/requests/requests/issues/3491
         request.headers = {
-            k: str(v)
+            k: str(v) if not isinstance(v, six.binary_type) else v
             for k, v in iteritems(request.headers)
         }
 

--- a/tests/fido_client/FidoClient/prepare_request_for_twisted_test.py
+++ b/tests/fido_client/FidoClient/prepare_request_for_twisted_test.py
@@ -38,6 +38,22 @@ def test_prepare_request_for_twisted_body_is_bytes():
     }
 
 
+def test_prepare_request_for_twisted_header_values_are_bytes():
+    request_params = {
+        'url': 'http://example.com/api-docs',
+        'headers': {b'X-Foo': b'hi'},
+        'method': 'GET',
+    }
+    request_for_twisted = FidoClient.prepare_request_for_twisted(request_params)
+
+    assert request_for_twisted == {
+        'body': None,
+        'headers': {'X-Foo': b'hi'},
+        'method': 'GET',
+        'url': 'http://example.com/api-docs'
+    }
+
+
 def test_prepare_request_for_twisted_timeouts_added():
     request_params = {
         'url': 'http://example.com/api-docs',

--- a/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
+++ b/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
@@ -1,19 +1,5 @@
 # -*- coding: utf-8 -*-
-import pytest
-from mock import Mock
-from requests.sessions import Session
-
 from bravado.requests_client import RequestsFutureAdapter
-
-
-@pytest.fixture
-def request():
-    return dict(url='http://foo.com')
-
-
-@pytest.fixture
-def session():
-    return Mock(spec=Session)
 
 
 def test_no_timeouts(session, request):

--- a/tests/requests_client/RequestsFutureAdapter/conftest.py
+++ b/tests/requests_client/RequestsFutureAdapter/conftest.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+import pytest
+from mock import Mock
+from requests.sessions import Session
+
+
+@pytest.fixture
+def request():
+    return Mock(url='http://foo.com')
+
+
+@pytest.fixture
+def session():
+    return Mock(spec=Session)

--- a/tests/requests_client/RequestsFutureAdapter/header_type_casting_test.py
+++ b/tests/requests_client/RequestsFutureAdapter/header_type_casting_test.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from bravado.requests_client import RequestsFutureAdapter
+
+
+def test_result_header_values_are_bytes(session, request):
+    request.headers = {b'X-Foo': b'hi'}
+    RequestsFutureAdapter(session, request, misc_options={}).result()
+
+    # prepare_request should be called with a request containing correctly
+    # casted headers (bytestrings should be preserved)
+    prepared_headers = session.prepare_request.call_args[0][0].headers
+    assert prepared_headers == {b'X-Foo': b'hi'}


### PR DESCRIPTION
[Since 9.0.2](https://github.com/Yelp/bravado/commit/3ca98af8b41c1a7f5865d4093411f6f3f6fcc497), we're mangling bytestring header values in py3:

```python
Python 3.6.0 (default, Feb  7 2017, 23:09:25)
[GCC 4.6.3] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> helper = b'mmulder'
>>> str(helper)
"b'mmulder'"
```

Since it looks like the 9.0.2 change was introduced specifically to cast booleans, we should be fine exempting binary_type from the casting.