### PR TITLE
Fix bytestring mangling for headers in swaggerpy

### DIFF
--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -184,7 +184,7 @@ class Operation(object):
             # to string. This is need to workaround
             # https://github.com/requests/requests/issues/3491
             _request_options['headers'] = dict(
-                (k, str(v))
+                (k, v if isinstance(v, six.binary_type) else str(v))
                 for k, v in six.iteritems(_request_options['headers'])
             )
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -200,6 +200,19 @@ class ClientTest(unittest.TestCase):
             )
 
     @httpretty.activate
+    def test_header_bytestrings(self):
+        self.uut = SwaggerClient.from_resource_listing(self.resource_listing)
+        httpretty.register_uri(
+            httpretty.GET, "http://swagger.py/swagger-test/pet",
+            body='[]',
+        )
+
+        self.uut.pet.listPets(
+            _request_options={'headers': {b'foo': b'bar'}},
+        ).result()
+        self.assertEqual('bar', httpretty.last_request().headers['foo'])
+
+    @httpretty.activate
     def test_get(self):
         httpretty.register_uri(
             httpretty.GET, "http://swagger.py/swagger-test/pet",


### PR DESCRIPTION
Same fix as #300 for Bravado.