### PR TITLE
Require newer fido version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+9.0.7 (2017-07-05)
+------------------
+- Require fido version 4.2.1 so we stay compatible to code catching crochet.TimeoutError
+
 9.0.6 (2017-06-28)
 ------------------
 - Don't mangle headers with bytestring values on Python 3

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,6 @@ setup(
         "six",
     ],
     extras_require={
-        "fido": ["fido >= 2.1.0"],
+        "fido": ["fido >= 4.2.1"],
     },
 )


### PR DESCRIPTION
That way fido.exceptions.HTTPTimeoutError is compatible with crochet.TimeoutError.