### PR TITLE
Make sure headers are unicode when using the fido client

### DIFF
--- a/CHANGELOG-MASTER.rst
+++ b/CHANGELOG-MASTER.rst
@@ -5,3 +5,7 @@ Changelog-Master
 
 *The content will be used to build the Changelog of the new bravado release.*
 
+- Make sure HTTP header names and values are unicode strings when using the fido HTTP client.
+  NOTE: this is a potentially backwards incompatible change if you're using the fido HTTP client and
+  are working with response headers. It's also highly advised to not upgrade to bravado-core 4.8.0+
+  if you're using fido unless you're also upgrading to a bravado version that contains this change.

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -6,6 +6,7 @@ import crochet
 import fido
 import fido.exceptions
 import requests
+import requests.structures
 import six
 from bravado_core.response import IncomingResponse
 from yelp_bytes import to_bytes
@@ -26,6 +27,7 @@ class FidoResponseAdapter(IncomingResponse):
 
     def __init__(self, fido_response):
         self._delegate = fido_response
+        self._headers = None
 
     @property
     def status_code(self):
@@ -41,7 +43,21 @@ class FidoResponseAdapter(IncomingResponse):
 
     @property
     def headers(self):
-        return self._delegate.headers
+        # Header names and values are bytestrings, which is an issue on Python 3. Additionally,
+        # header values are lists of strings. This is incompatible with how requests returns headers.
+        # Let's match the requests interface so code dealing with headers continues to work even when
+        # you change the HTTP client.
+        if not self._headers:
+            self._headers = requests.structures.CaseInsensitiveDict()
+            for header, values in self._delegate.headers.items():
+                # header names are encoded using latin1, while header values are encoded using UTF-8.
+                # We'll take the last entry in the list of values, making sure the latest header sent
+                # takes precedence. The fact that twisted uses lists of strings for values seems to be
+                # an edge case, I couldn't find any documentation or test using more than one entry in
+                # the list of values for a given header.
+                self._headers[header.decode('latin1')] = values[-1].decode('utf8')
+
+        return self._headers
 
     def json(self, **_):
         # TODO: pass the kwargs downstream

--- a/tests/fido_client/fido_response_adapter_test.py
+++ b/tests/fido_client/fido_response_adapter_test.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import mock
+
+from bravado.fido_client import FidoResponseAdapter
+
+
+def test_header_conversion():
+    fido_response = mock.Mock(
+        name='fido_response',
+        headers={
+            b'Content-Type': [b'application/json'],
+            'x-weird-ä'.encode('latin1'): ['ümläüt'.encode('utf8')],
+            b'X-Multiple': [b'donotuse', b'usethis'],
+        },
+    )
+
+    response_adapter = FidoResponseAdapter(fido_response)
+    assert response_adapter.headers == {
+        'content-type': 'application/json',
+        'X-WEIRD-ä': 'ümläüt',
+        'X-Multiple': 'usethis',
+    }

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -10,7 +10,7 @@ import yaml
 API_DOCS_URL = "http://localhost/api-docs"
 
 # Convenience for httpretty.register_uri(httpretty.GET, **kwargs)
-register_get = functools.partial(httpretty.register_uri, httpretty.GET)
+register_get = functools.partial(httpretty.register_uri, httpretty.GET, content_type='application/json')
 
 
 def register_spec(swagger_dict, response_spec=None, spec_type='json'):


### PR DESCRIPTION
This change makes sure header names and values are the same as with the requests client when using the fido client. twisted (the underlying library fido uses) returns headers as a dictionary of binary string keys and lists of binary string values. They are now both unicode strings, and the header names can be accessed in a case-insensitive manner.

Due to our almost non-existing integration test coverage for the fido client we can't really rely on tests to tell us if this change breaks anything. If I have time I'll try to work on that later.

bravado-core 4.8.0 also broke a bunch of bravado tests, the one line change in conftest.py fixes them.