### PR TITLE
Add HTTP proxy support

### DIFF
--- a/CHANGELOG-MASTER.rst
+++ b/CHANGELOG-MASTER.rst
@@ -1,7 +1,5 @@
 Changelog-Master
 ================
 
-*This file will contain the Changelog of the master branch.*
-
-*The content will be used to build the Changelog of the new bravado release.*
+- Add HTTP proxy support for requests client via Bravado config
 

--- a/bravado/client.py
+++ b/bravado/client.py
@@ -141,6 +141,10 @@ class SwaggerClient(object):
         # Apply bravado config defaults
         config = dict(CONFIG_DEFAULTS, **(config or {}))
 
+        # Apply bravado proxy settings
+        if 'proxies' in config:
+            http_client.updateProxies(config['proxies'])
+
         swagger_spec = Spec.from_dict(
             spec_dict, origin_url, http_client, config)
         return cls(swagger_spec)

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -123,6 +123,15 @@ class RequestsClient(HttpClient):
 
         return sanitized_params, misc_options
 
+    def updateProxies(self, proxies):
+        """
+        :param proxies: proxies for Requests session
+        :type proxies: dict
+
+        :returns None
+        """
+        self.session.proxies.update(proxies)
+
     def request(self, request_params, operation=None, response_callbacks=None,
                 also_return_response=False):
         """


### PR DESCRIPTION
HTTP proxy support for requests client via Bravado config

Example with HTTP proxy:

from bravado.client import SwaggerClient

config = {
    # set HTTP proxies for requests
    'proxies': {'http': 'http://127.0.0.1:8080'}
}

client = SwaggerClient.from_url('http://petstore.swagger.io/v2/swagger.json', config=config)
pet = client.pet.getPetById(petId=42).result()
