### PR TITLE
Require requests >= 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "bravado-core >= 4.2.2",
         "python-dateutil",
         "pyyaml",
-        "requests",
+        "requests >= 2",
         "six",
     ],
     extras_require={


### PR DESCRIPTION
RequestsClient calls requests Session.prepare_request (among others?) which is only present in 2.0.0 and above.