### PR TITLE
Unify timeout errors

### DIFF
--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
-from six import with_metaclass
+try:
+    from builtins import TimeoutError as base_exception
+except ImportError:
+    # TimeoutError was introduced in python 3.3+
+    base_exception = Exception
 
+
+from six import with_metaclass
 
 # Dictionary of HTTP status codes to exception classes
 status_map = {}
@@ -230,3 +236,7 @@ class HTTPNotExtended(HTTPServerError):
 
 class HTTPNetworkAuthenticationRequired(HTTPServerError):
     status_code = 511
+
+
+class BravadoTimeoutError(base_exception):
+    pass

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -167,6 +167,8 @@ class FidoFutureAdapter(FutureAdapter):
     retrieve results.
     """
 
+    timeout_errors = [fido.exceptions.HTTPTimeoutError]
+
     def __init__(self, eventual_result):
         self._eventual_result = eventual_result
 

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -35,7 +35,7 @@ class FutureAdapter(object):
         )
 
 
-def raraise_timeout_errors(func):
+def reraise_errors(func):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         timeout_errors = tuple(getattr(self.future, 'timeout_errors', None) or ())
@@ -95,7 +95,7 @@ class HttpFuture(object):
         self.response_callbacks = response_callbacks or []
         self.also_return_response = also_return_response
 
-    @raraise_timeout_errors
+    @reraise_errors
     def result(self, timeout=None):
         """Blocking call to wait for the HTTP response.
 

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 import sys
+from functools import wraps
 
 import bravado_core
 import six
 from bravado_core.exception import MatchingResponseNotFound
 
+from bravado.exception import BravadoTimeoutError
 from bravado.exception import make_http_exception
 
 
@@ -18,6 +20,9 @@ class FutureAdapter(object):
 
     """
 
+    # Make sure to define the timeout errors associated with your http client
+    timeout_errors = []
+
     def result(self, timeout=None):
         """
         Must implement a result method which blocks on result retrieval.
@@ -28,6 +33,37 @@ class FutureAdapter(object):
         raise NotImplementedError(
             "FutureAdapter must implement 'result' method"
         )
+
+
+def raraise_timeout_errors(func):
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        timeout_errors = tuple(getattr(self.future, 'timeout_errors', None) or ())
+
+        # Make sure that timeout error type for a specific future adapter is generated only once
+        if timeout_errors and getattr(self.future, '__timeout_error_type', None) is None:
+            setattr(
+                self.future, '__timeout_error_type',
+                type(
+                    '{}Timeout'.format(self.future.__class__.__name__),
+                    tuple(list(timeout_errors) + [BravadoTimeoutError]),
+                    dict(),
+                ),
+            )
+
+        if timeout_errors:
+            try:
+                return func(self, *args, **kwargs)
+            except timeout_errors as exception:
+                six.reraise(
+                    self.future.__timeout_error_type,
+                    self.future.__timeout_error_type(*exception.args),
+                    sys.exc_info()[2],
+                )
+        else:
+            return func(self, *args, **kwargs)
+
+    return wrapper
 
 
 class HttpFuture(object):
@@ -59,6 +95,7 @@ class HttpFuture(object):
         self.response_callbacks = response_callbacks or []
         self.also_return_response = also_return_response
 
+    @raraise_timeout_errors
     def result(self, timeout=None):
         """Blocking call to wait for the HTTP response.
 

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -209,6 +209,8 @@ class RequestsFutureAdapter(FutureAdapter):
     HTTP calls with the Requests library in a future-y sort of way.
     """
 
+    timeout_errors = [requests.Timeout]
+
     def __init__(self, session, request, misc_options):
         """Kicks API call for Requests client
 

--- a/tests/http_future/HttpFuture/result_test.py
+++ b/tests/http_future/HttpFuture/result_test.py
@@ -10,30 +10,35 @@ from bravado.http_future import FutureAdapter
 from bravado.http_future import HttpFuture
 
 
-def test_200_get_swagger_spec():
+@pytest.fixture
+def mock_future_adapter():
+    return Mock(spec=FutureAdapter, timeout_errors=None)
+
+
+def test_200_get_swagger_spec(mock_future_adapter):
     response_adapter_instance = Mock(spec=IncomingResponse, status_code=200)
     response_adapter_type = Mock(return_value=response_adapter_instance)
     http_future = HttpFuture(
-        future=Mock(spec=FutureAdapter),
+        future=mock_future_adapter,
         response_adapter=response_adapter_type)
 
     assert response_adapter_instance == http_future.result()
 
 
-def test_500_get_swagger_spec():
+def test_500_get_swagger_spec(mock_future_adapter):
     response_adapter_instance = Mock(spec=IncomingResponse, status_code=500)
     response_adapter_type = Mock(return_value=response_adapter_instance)
 
     with pytest.raises(HTTPError) as excinfo:
         HttpFuture(
-            future=Mock(spec=FutureAdapter),
+            future=mock_future_adapter,
             response_adapter=response_adapter_type).result()
 
     assert excinfo.value.response.status_code == 500
 
 
 @patch('bravado.http_future.unmarshal_response', autospec=True)
-def test_200_service_call(_):
+def test_200_service_call(_, mock_future_adapter):
     response_adapter_instance = Mock(
         spec=IncomingResponse,
         status_code=200,
@@ -42,7 +47,7 @@ def test_200_service_call(_):
     response_adapter_type = Mock(return_value=response_adapter_instance)
 
     http_future = HttpFuture(
-        future=Mock(spec=FutureAdapter),
+        future=mock_future_adapter,
         response_adapter=response_adapter_type,
         operation=Mock(spec=Operation))
 
@@ -50,7 +55,7 @@ def test_200_service_call(_):
 
 
 @patch('bravado.http_future.unmarshal_response', autospec=True)
-def test_400_service_call(mock_unmarshal_response):
+def test_400_service_call(mock_unmarshal_response, mock_future_adapter):
     response_adapter_instance = Mock(
         spec=IncomingResponse,
         status_code=400,
@@ -59,7 +64,7 @@ def test_400_service_call(mock_unmarshal_response):
     response_adapter_type = Mock(return_value=response_adapter_instance)
 
     http_future = HttpFuture(
-        future=Mock(spec=FutureAdapter),
+        future=mock_future_adapter,
         response_adapter=response_adapter_type,
         operation=Mock(spec=Operation))
 
@@ -69,7 +74,7 @@ def test_400_service_call(mock_unmarshal_response):
 
 
 @patch('bravado.http_future.unmarshal_response', autospec=True)
-def test_also_return_response_true(_):
+def test_also_return_response_true(_, mock_future_adapter):
     # Verify HTTPFuture(..., also_return_response=True).result()
     # returns the (swagger_result, http_response) and not just swagger_result
     response_adapter_instance = Mock(
@@ -79,7 +84,7 @@ def test_also_return_response_true(_):
     response_adapter_type = Mock(return_value=response_adapter_instance)
 
     http_future = HttpFuture(
-        future=Mock(spec=FutureAdapter),
+        future=mock_future_adapter,
         response_adapter=response_adapter_type,
         operation=Mock(spec=Operation),
         also_return_response=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,6 +36,13 @@ def double():
     return str(int(x) * 2)
 
 
+@bottle.route("/sleep")
+def sleep_api():
+    sec_to_sleep = float(bottle.request.GET.get('sec', '1'))
+    time.sleep(sec_to_sleep)
+    return sec_to_sleep
+
+
 def wait_unit_service_starts(url, timeout=10):
     start = time.time()
     while time.time() < start + timeout:
@@ -55,5 +62,6 @@ def threaded_http_server():
     )
     thread.daemon = True
     thread.start()
-    wait_unit_service_starts('http://localhost:{port}'.format(port=port))
-    yield port
+    server_address = 'http://localhost:{port}'.format(port=port)
+    wait_unit_service_starts(server_address)
+    yield server_address

--- a/tests/integration/fido_client_test.py
+++ b/tests/integration/fido_client_test.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from bravado.fido_client import FidoClient
+from bravado.fido_client import FidoFutureAdapter
 from tests.integration import requests_client_test
 
 
 class TestServerFidoClient(requests_client_test.TestServerRequestsClient):
 
-    @classmethod
-    def setup_class(cls):
-        cls.http_client = FidoClient()
+    http_client_type = FidoClient
+    http_future_adapter_type = FidoFutureAdapter
 
     @classmethod
     def encode_expected_response(cls, response):

--- a/tests/integration/requests_client_test.py
+++ b/tests/integration/requests_client_test.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
+import pytest
+import requests
+from mock import mock
+
+from bravado.exception import BravadoTimeoutError
 from bravado.requests_client import RequestsClient
+from bravado.requests_client import RequestsFutureAdapter
 from bravado.swagger_model import Loader
 from tests.integration.conftest import ROUTE_1_RESPONSE
 from tests.integration.conftest import ROUTE_2_RESPONSE
@@ -7,9 +13,16 @@ from tests.integration.conftest import ROUTE_2_RESPONSE
 
 class TestServerRequestsClient:
 
+    http_client_type = RequestsClient
+    http_future_adapter_type = RequestsFutureAdapter
+
     @classmethod
     def setup_class(cls):
-        cls.http_client = RequestsClient()
+        if cls.http_client_type is None:
+            raise RuntimeError('Define http_client_type for {}'.format(cls.__name__))
+        if cls.http_future_adapter_type is None:
+            raise RuntimeError('Define http_future_adapter_type for {}'.format(cls.__name__))
+        cls.http_client = cls.http_client_type()
 
     @classmethod
     def encode_expected_response(cls, response):
@@ -23,7 +36,7 @@ class TestServerRequestsClient:
             http_client=self.http_client,
             request_headers={'boolean-header': True},
         )
-        spec = loader.load_spec('http://localhost:{0}/swagger.json'.format(threaded_http_server))
+        spec = loader.load_spec('{server_address}/swagger.json'.format(server_address=threaded_http_server))
         assert spec == petstore_dict
 
     def test_multiple_requests(self, threaded_http_server):
@@ -31,14 +44,14 @@ class TestServerRequestsClient:
         request_one_params = {
             'method': 'GET',
             'headers': {},
-            'url': "http://localhost:{0}/1".format(threaded_http_server),
+            'url': '{server_address}/1'.format(server_address=threaded_http_server),
             'params': {},
         }
 
         request_two_params = {
             'method': 'GET',
             'headers': {},
-            'url': "http://localhost:{0}/2".format(threaded_http_server),
+            'url': '{server_address}/2'.format(server_address=threaded_http_server),
             'params': {},
         }
 
@@ -55,7 +68,7 @@ class TestServerRequestsClient:
         request_args = {
             'method': 'POST',
             'headers': {},
-            'url': "http://localhost:{0}/double".format(threaded_http_server),
+            'url': '{server_address}/double'.format(server_address=threaded_http_server),
             'data': {"number": 3},
         }
 
@@ -68,8 +81,73 @@ class TestServerRequestsClient:
         response = self.http_client.request({
             'method': 'GET',
             'headers': {'boolean-header': True},
-            'url': "http://localhost:{0}/1".format(threaded_http_server),
+            'url': '{server_address}/1'.format(server_address=threaded_http_server),
             'params': {},
         }).result(timeout=1)
 
         assert response.text == self.encode_expected_response(ROUTE_1_RESPONSE)
+
+    def test_timeout_errors_are_thrown_as_BravadoTimeoutError(self, threaded_http_server):
+        timeout_errors = getattr(self.http_future_adapter_type, 'timeout_errors', [])
+        if not timeout_errors:
+            pytest.skip('{} does NOT defines timeout_errors'.format(self.http_future_adapter_type))
+
+        with pytest.raises(BravadoTimeoutError):
+            self.http_client.request({
+                'method': 'GET',
+                'url': '{server_address}/sleep?sec=0.1'.format(server_address=threaded_http_server),
+                'params': {},
+            }).result(timeout=0.01)
+
+    def test_timeout_errors_are_catchable_with_original_exception_types(self, threaded_http_server):
+        timeout_errors = getattr(self.http_future_adapter_type, 'timeout_errors', [])
+        if not timeout_errors:
+            pytest.skip('{} does NOT defines timeout_errors'.format(self.http_future_adapter_type))
+
+        for expected_exception in timeout_errors:
+            with pytest.raises(expected_exception):
+                self.http_client.request({
+                    'method': 'GET',
+                    'url': '{server_address}/sleep?sec=0.1'.format(server_address=threaded_http_server),
+                    'params': {},
+                }).result(timeout=0.01)
+
+
+class FakeRequestsFutureAdapter(RequestsFutureAdapter):
+    timeout_errors = []
+
+
+class FakeRequestsClient(RequestsClient):
+    @mock.patch('bravado.requests_client.RequestsFutureAdapter', FakeRequestsFutureAdapter)
+    def request(self, *args, **kwargs):
+        return super(FakeRequestsClient, self).request(*args, **kwargs)
+
+
+class TestServerRequestsClientFake(TestServerRequestsClient):
+    """
+    This test class uses as http client a requests client that has no timeout error specified.
+    This is needed to ensure that the changes are back compatible
+    """
+
+    http_client_type = FakeRequestsClient
+    http_future_adapter_type = FakeRequestsFutureAdapter
+
+    def test_timeout_error_not_throws_BravadoTimeoutError_if_no_timeout_errors_specified(self, threaded_http_server):
+        try:
+            self.http_client.request({
+                'method': 'GET',
+                'url': '{server_address}/sleep?sec=0.1'.format(server_address=threaded_http_server),
+                'params': {},
+            }).result(timeout=0.01)
+        except BravadoTimeoutError:
+            pytest.fail('DID RAISE BravadoTimeoutError')
+        except:
+            pass
+
+    def test_timeout_errors_are_catchable_with_original_exception_types(self, threaded_http_server):
+        with pytest.raises(requests.Timeout):
+            self.http_client.request({
+                'method': 'GET',
+                'url': '{server_address}/sleep?sec=0.1'.format(server_address=threaded_http_server),
+                'params': {},
+            }).result(timeout=0.01)


### PR DESCRIPTION
The goal of this PR is to provide a standard way of catching timeout error thrown by the different HTTP clients implementation.

It exposes a new exception ``BravadoTimeoutError`` which will be used as base class of the different HTTP timeout errors.

The _magic_ is provided by ``raraise_timeout_errors`` decorator.
The decorator ensures that whenever ``HttpFuture.result`` is called it will reraise timeout errors (defined by ``FutureAdapter.timeout_errors`` attribute) that could be catched as ``BravadoTimeoutError`` exceptions.

To make this change transparent and compatible with third-party HTTP clients (like [bravado-asyncio](https://github.com/sjaensch/bravado-asyncio)) the decorator does no assumption about the presence of ``timeout_errors`` attribute in the future adapter class.

While preparing this PR I have also extracted all the base logic for the integration tests to a common file (``conftest.py``). This should simplify, via another PR, to expose them to third-party clients implementations.