### PR TITLE
Fix do not use bare except flake8 error

### DIFF
--- a/tests/integration/requests_client_test.py
+++ b/tests/integration/requests_client_test.py
@@ -141,7 +141,7 @@ class TestServerRequestsClientFake(TestServerRequestsClient):
             }).result(timeout=0.01)
         except BravadoTimeoutError:
             pytest.fail('DID RAISE BravadoTimeoutError')
-        except:
+        except Exception:
             pass
 
     def test_timeout_errors_are_catchable_with_original_exception_types(self, threaded_http_server):


### PR DESCRIPTION
The goal of this PR is to fix [travis build failure](https://travis-ci.org/Yelp/bravado/jobs/291579067).
The failure is related to a new release of flake8