### PR TITLE
Also return response not in bravado core configs

### DIFF
--- a/bravado/client.py
+++ b/bravado/client.py
@@ -108,7 +108,7 @@ class SwaggerClient(object):
 
         :rtype: :class:`bravado_core.spec.Spec`
         """
-        log.debug(u"Loading from %s" % spec_url)
+        log.debug(u"Loading from %s", spec_url)
         http_client = http_client or RequestsClient()
         loader = Loader(http_client, request_headers=request_headers)
         spec_dict = loader.load_spec(spec_url)
@@ -249,7 +249,7 @@ class CallableOperation(object):
 
         :rtype: :class:`bravado.http_future.HTTPFuture`
         """
-        log.debug(u"%s(%s)" % (self.operation.operation_id, op_kwargs))
+        log.debug(u'%s(%s)', self.operation.operation_id, op_kwargs)
         warn_for_deprecated_op(self.operation)
 
         # Apply request_options defaults

--- a/bravado/client.py
+++ b/bravado/client.py
@@ -86,7 +86,8 @@ class SwaggerClient(object):
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     """
 
-    def __init__(self, swagger_spec):
+    def __init__(self, swagger_spec, also_return_response=False):
+        self.__also_return_response = also_return_response
         self.swagger_spec = swagger_spec
 
     @classmethod
@@ -141,9 +142,11 @@ class SwaggerClient(object):
         # Apply bravado config defaults
         config = dict(CONFIG_DEFAULTS, **(config or {}))
 
+        also_return_response = config.pop('also_return_response', False)
         swagger_spec = Spec.from_dict(
-            spec_dict, origin_url, http_client, config)
-        return cls(swagger_spec)
+            spec_dict, origin_url, http_client, config,
+        )
+        return cls(swagger_spec, also_return_response=also_return_response)
 
     def get_model(self, model_name):
         return self.swagger_spec.definitions[model_name]
@@ -161,7 +164,7 @@ class SwaggerClient(object):
 
         # Wrap bravado-core's Resource and Operation objects in order to
         # execute a service call via the http_client.
-        return ResourceDecorator(resource)
+        return ResourceDecorator(resource, self.__also_return_response)
 
     def __repr__(self):
         return u"%s(%s)" % (self.__class__.__name__, self.swagger_spec.api_url)
@@ -200,17 +203,18 @@ class ResourceDecorator(object):
     operations can be instrumented.
     """
 
-    def __init__(self, resource):
+    def __init__(self, resource, also_return_response=False):
         """
         :type resource: :class:`bravado_core.resource.Resource`
         """
+        self.also_return_response = also_return_response
         self.resource = resource
 
     def __getattr__(self, name):
         """
         :rtype: :class:`CallableOperation`
         """
-        return CallableOperation(getattr(self.resource, name))
+        return CallableOperation(getattr(self.resource, name), self.also_return_response)
 
     def __dir__(self):
         """
@@ -226,7 +230,8 @@ class CallableOperation(object):
     :type operation: :class:`bravado_core.operation.Operation`
     """
 
-    def __init__(self, operation):
+    def __init__(self, operation, also_return_response=False):
+        self.also_return_response = also_return_response
         self.operation = operation
 
     @docstring_property(__doc__)
@@ -255,13 +260,13 @@ class CallableOperation(object):
         request_params = construct_request(
             self.operation, request_options, **op_kwargs)
 
-        config = self.operation.swagger_spec.config
         http_client = self.operation.swagger_spec.http_client
 
         # Per-request config overrides client wide config
         also_return_response = request_options.get(
             'also_return_response',
-            config['also_return_response'])
+            self.also_return_response,
+        )
 
         return http_client.request(
             request_params,

--- a/bravado/compat.py
+++ b/bravado/compat.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
 try:
-    import simplejson as json
+    import simplejson as json  # pylint:disable=unused-import
 except ImportError:
     import json  # noqa

--- a/bravado/docstring_property.py
+++ b/bravado/docstring_property.py
@@ -48,11 +48,10 @@ class DocstringProperty(object):
         self.class_doc = class_doc
         self.fget = fget
 
-    def __get__(self, obj, type=None):
-        if obj is None:
+    def __get__(self, obj, objtype=None):
+        if objtype is None:
             return self.class_doc
-        else:
-            return self.fget(obj)
+        return self.fget(obj)
 
     def __set__(self, obj, value):
         raise AttributeError("can't set attribute")

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -160,9 +160,11 @@ class RequestsClient(HttpClient):
         self.authenticator = BasicAuthenticator(
             host=host, username=username, password=password)
 
-    def set_api_key(self, host, api_key, param_name=u'api_key', param_in=u'query'):
+    def set_api_key(self, host, api_key, param_name=u'api_key',
+                    param_in=u'query'):
         self.authenticator = ApiKeyAuthenticator(
-            host=host, api_key=api_key, param_name=param_name, param_in=param_in)
+            host=host, api_key=api_key, param_name=param_name,
+            param_in=param_in)
 
     def authenticated_request(self, request_params):
         return self.apply_authentication(requests.Request(**request_params))
@@ -256,10 +258,12 @@ class RequestsFutureAdapter(FutureAdapter):
                 timeout = service_timeout
             else:
                 timeout = max(service_timeout, result_timeout)
-            log.warn("Two different timeouts have been passed: "
-                     "_request_options['timeout'] = {0} and "
-                     "future.result(timeout={1}). Using timeout of {2}."
-                     .format(service_timeout, result_timeout, timeout))
+            log.warning(
+                "Two different timeouts have been passed: "
+                "_request_options['timeout'] = %s and "
+                "future.result(timeout=%s). Using timeout of %s.",
+                service_timeout, result_timeout, timeout,
+            )
 
         # Requests is weird in that if you want to specify a connect_timeout
         # and idle timeout, then the timeout is passed as a tuple

--- a/bravado/swagger_model.py
+++ b/bravado/swagger_model.py
@@ -6,6 +6,8 @@ import os.path
 
 import yaml
 from bravado_core.spec import is_yaml
+from six import iteritems
+from six import itervalues
 from six.moves import urllib
 from six.moves.urllib import parse as urlparse
 
@@ -42,7 +44,7 @@ class FileEventual(object):
             return self.path + '.json'
         return self.path
 
-    def wait(self, timeout=None):
+    def wait(self, **kwargs):
         with contextlib.closing(urllib.request.urlopen(self.get_path())) as fp:
             content = fp.read()
             return self.FileResponse(content)
@@ -115,15 +117,13 @@ class Loader(object):
         :raise: yaml.parser.ParserError: If the text is not valid YAML.
         """
         data = yaml.safe_load(text)
-        for path, methods in iter(data.get('paths', {}).items()):
-            for method, operation in iter(methods.items()):
+        for methods in itervalues(data.get('paths', {})):
+            for operation in itervalues(methods):
                 if 'responses' in operation:
-                    operation['responses'] = dict(
-                        (str(code), response)
-                        for code, response in iter(
-                            operation['responses'].items()
-                        )
-                    )
+                    operation['responses'] = {
+                        str(code): response
+                        for code, response in iteritems(operation['responses'])
+                    }
 
         return data
 


### PR DESCRIPTION
Currently, master branch fails to build due to a new bravado-core release that removes all the "extraneous" configurations. The issue was reported on [``bravado-core``  #217](https://github.com/Yelp/bravado-core/issues/217).

``braavdo`` was used to inject ``also_return_response`` config into ``bravado-core`` config for ease sharing of information during response handling.

With this PR I'm proposing a different approach (respect [``bravado-core`` PR #218](https://github.com/Yelp/bravado-core/pull/218)) to fix the issue. The idea is to propagate the config by using a class attribute in ``ResourceDecorator`` and ``OperationDecorator``.

This will allow to fix the issue and to avoid to pollute external libraries configurations, which we should not do 😄.

I've tested this solution by running tests with some Yelp internal services (this change is compatible with the custom ``bravado-decorators`` in use).

**NOTE**: if this PR get's accepted we can discard [``bravado-core`` PR #218](https://github.com/Yelp/bravado-core/pull/218) change.

ℹ️ : I've also fixed some pylint warning provided by [landscape.io](https://landscape.io/github/macisamuele/bravado/1/messages)