### PR TITLE
Add integration test for raw_bytes

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ mock
 pip>=9.0.1 # workaround to https://github.com/pypa/pip/issues/3903
 pre-commit
 pytest
+umsgpack

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,6 +6,7 @@ import time
 import bottle
 import ephemeral_port_reserve
 import pytest
+import umsgpack
 from six.moves import urllib
 
 from tests.conftest import petstore_dict
@@ -13,6 +14,7 @@ from tests.conftest import test_dir
 
 ROUTE_1_RESPONSE = b"HEY BUDDY"
 ROUTE_2_RESPONSE = b"BYE BUDDY"
+MSGPACK_RESPONSE = {'answer': 42}
 
 
 @bottle.get("/swagger.json")
@@ -36,7 +38,13 @@ def double():
     return str(int(x) * 2)
 
 
-@bottle.route("/sleep")
+@bottle.route('/msgpack')
+def msgpack():
+    bottle.response.content_type = 'application/msgpack'
+    return umsgpack.packb(MSGPACK_RESPONSE)
+
+
+@bottle.get("/sleep")
 def sleep_api():
     sec_to_sleep = float(bottle.request.GET.get('sec', '1'))
     time.sleep(sec_to_sleep)


### PR DESCRIPTION
This basically makes sure raw_bytes behaves correctly and works with msgpack. It's not a full integration test using bravado-core unmarshalling. I'm going to publish that as part of bravado-asyncio (I have it written already) once we have releases of bravado-core and bravado with msgpack support.

This test is run for both the requests as well as the fido client, since the fido integration test class inherits from `TestServerRequestsClient`.