### PR TITLE
SwaggerClient into integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,4 +14,4 @@ def test_dir():
 def petstore_dict(test_dir):
     fpath = os.path.join(test_dir, '../test-data/2.0/petstore/swagger.json')
     with open(fpath) as f:
-        return json.loads(f.read())
+        return json.load(f)


### PR DESCRIPTION
Updated integration tests to include tests with ``bravado.client.SwaggerClient``.
The tests handle JSON and msgpack tests 😄 

It would be nice to have this merged before releasing the new version.