### PR TITLE
Add a _use_msgpack option

### DIFF
--- a/bravado/client.py
+++ b/bravado/client.py
@@ -275,7 +275,7 @@ class CallableOperation(object):
             also_return_response=also_return_response)
 
 
-def construct_request(operation, request_options, **op_kwargs):
+def construct_request(operation, request_options, _use_msgpack=False, **op_kwargs):
     """Construct the outgoing request dict.
 
     :type operation: :class:`bravado_core.operation.Operation`
@@ -293,6 +293,9 @@ def construct_request(operation, request_options, **op_kwargs):
         'params': {},  # filled in downstream
         'headers': request_options.get('headers', {}),
     }
+    # Adds Accept header to request for msgpack response if specified
+    if _use_msgpack:
+        request['headers']['Accept'] = 'application/msgpack'
 
     # Copy over optional request options
     for request_option in ('connect_timeout', 'timeout'):


### PR DESCRIPTION
Fixes #333 - Adds a _use_msgpack option for users to more easily specify that they want to request msgpack content and add the Accept header

## Testing (Manual)
- Added a print line in `bravado.requests_client.RequestsResponseAdapter.raw_bytes`
- In a `python` shell, imported `bravado` and created a client to a spec and server that would produce a `application/msgpack` Content-Type when the `Accept:` header is received, and JSON in all other cases
- Used the client to request a endpoint with no `_use_msgpack` specified and verified that JSON was printed from `raw_bytes` and the correct JSON was returned from `result()`
- Used the client to request a endpoint with `_use_msgpack=True` and verified that msgpack binary was printed and the correct JSON was returned from `result()`

(Note that all tests in `tests/client_test.py` xfailed, so I could not add a test to it and have it run properly)