### PR TITLE
Use ReadTimeout as base timeout exception for the requests client

### DIFF
--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -3,6 +3,7 @@ import logging
 
 import requests
 import requests.auth
+import requests.exceptions
 import six
 from bravado_core.response import IncomingResponse
 from six import iteritems
@@ -215,7 +216,7 @@ class RequestsFutureAdapter(FutureAdapter):
     HTTP calls with the Requests library in a future-y sort of way.
     """
 
-    timeout_errors = [requests.Timeout]
+    timeout_errors = [requests.exceptions.ReadTimeout]
 
     def __init__(self, session, request, misc_options):
         """Kicks API call for Requests client

--- a/tests/integration/requests_client_test.py
+++ b/tests/integration/requests_client_test.py
@@ -4,6 +4,7 @@ import json
 import mock
 import pytest
 import requests
+import requests.exceptions
 import umsgpack
 from bravado_core.content_type import APP_MSGPACK
 
@@ -146,6 +147,17 @@ class TestServerRequestsClient:
                     'url': '{server_address}/sleep?sec=0.1'.format(server_address=threaded_http_server),
                     'params': {},
                 }).result(timeout=0.01)
+
+    def test_timeout_errors_are_catchable_as_requests_timeout(self, threaded_http_server):
+        if not self.http_client_type == RequestsClient:
+            pytest.skip('{} is not using RequestsClient'.format(self.http_future_adapter_type))
+
+        with pytest.raises(requests.exceptions.Timeout):
+            self.http_client.request({
+                'method': 'GET',
+                'url': '{server_address}/sleep?sec=0.1'.format(server_address=threaded_http_server),
+                'params': {},
+            }).result(timeout=0.01)
 
 
 class FakeRequestsFutureAdapter(RequestsFutureAdapter):


### PR DESCRIPTION
This fixes issues with code that catches requests.exceptions.ReadTimeout, which we broke by using requests.exceptions.Timeout as base class.