### PR TITLE
#339: Make umsgpack an extra and handle its absence

### DIFF
--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -3,7 +3,11 @@ import sys
 from functools import wraps
 
 import six
-import umsgpack
+try:
+    from umsgpack import unpackb
+except ImportError:
+    unpackb = None
+
 from bravado_core.content_type import APP_JSON
 from bravado_core.content_type import APP_MSGPACK
 from bravado_core.exception import MatchingResponseNotFound
@@ -193,8 +197,10 @@ def unmarshal_response_inner(response, op):
         content_spec = deref(response_spec['schema'])
         if content_type.startswith(APP_JSON):
             content_value = response.json()
+        elif unpackb is None:
+            raise Exception("umsgpack is required")
         else:
-            content_value = umsgpack.unpackb(response.raw_bytes)
+            content_value = unpackb(response.raw_bytes)
 
         if op.swagger_spec.config.get('validate_responses', False):
             validate_schema_object(op.swagger_spec, content_spec, content_value)

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,6 @@ setup(
     ],
     extras_require={
         "fido": ["fido >= 4.2.1"],
+        "umsgpack": ["umsgpack >= 0.1.0"],
     },
 )


### PR DESCRIPTION
The addition of `umsgpack` is a breaking change. It should be handled more gracefully:

 -  Catch the import error
 -  Raise an exception if needed but not installed
 -  Add an extra dependency