### PR TITLE
Using umsgpack breaks because it is not a dependency

### DIFF
--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -194,7 +194,7 @@ def unmarshal_response_inner(response, op):
         if content_type.startswith(APP_JSON):
             content_value = response.json()
         else:
-            content_value = unpackb(response.raw_bytes)
+            content_value = unpackb(response.raw_bytes, encoding='utf-8')
 
         if op.swagger_spec.config.get('validate_responses', False):
             validate_schema_object(op.swagger_spec, content_spec, content_value)

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -3,7 +3,7 @@ import sys
 from functools import wraps
 
 import six
-import umsgpack
+from msgpack import unpackb
 from bravado_core.content_type import APP_JSON
 from bravado_core.content_type import APP_MSGPACK
 from bravado_core.exception import MatchingResponseNotFound
@@ -194,7 +194,7 @@ def unmarshal_response_inner(response, op):
         if content_type.startswith(APP_JSON):
             content_value = response.json()
         else:
-            content_value = umsgpack.unpackb(response.raw_bytes)
+            content_value = unpackb(response.raw_bytes)
 
         if op.swagger_spec.config.get('validate_responses', False):
             validate_schema_object(op.swagger_spec, content_spec, content_value)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,7 @@ import time
 import bottle
 import ephemeral_port_reserve
 import pytest
-import umsgpack
+from msgpack import packb
 from bravado_core.content_type import APP_JSON
 from bravado_core.content_type import APP_MSGPACK
 from six.moves import urllib
@@ -76,7 +76,7 @@ def api_json():
 def api_json_or_msgpack():
     if bottle.request.headers.get('accept') == APP_MSGPACK:
         bottle.response.content_type = APP_MSGPACK
-        return umsgpack.packb(API_RESPONSE)
+        return packb(API_RESPONSE)
     else:
         return API_RESPONSE
 

--- a/tests/integration/requests_client_test.py
+++ b/tests/integration/requests_client_test.py
@@ -5,7 +5,7 @@ import mock
 import pytest
 import requests
 import requests.exceptions
-import umsgpack
+from msgpack import packb, unpackb
 from bravado_core.content_type import APP_MSGPACK
 
 from bravado.client import SwaggerClient
@@ -73,7 +73,7 @@ class TestServerRequestsClient:
             },
         ).result(timeout=1)
         assert marshaled_response == API_RESPONSE
-        assert raw_response.raw_bytes == umsgpack.packb(API_RESPONSE)
+        assert raw_response.raw_bytes == packb(API_RESPONSE)
 
     def test_multiple_requests(self, threaded_http_server):
         request_one_params = {
@@ -133,7 +133,7 @@ class TestServerRequestsClient:
         }).result(timeout=1)
 
         assert response.headers['Content-Type'] == APP_MSGPACK
-        assert umsgpack.unpackb(response.raw_bytes) == API_RESPONSE
+        assert unpackb(response.raw_bytes, encoding='utf-8') == API_RESPONSE
 
     def test_timeout_errors_are_thrown_as_BravadoTimeoutError(self, threaded_http_server):
         timeout_errors = getattr(self.http_future_adapter_type, 'timeout_errors', [])


### PR DESCRIPTION
Per feedback from #340, remove explicit `umsgpack` usage