### PR TITLE
Add twisted errors to list of Fido timeouts

### DIFF
--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -8,6 +8,7 @@ import fido.exceptions
 import requests
 import requests.structures
 import six
+import twisted
 from bravado_core.response import IncomingResponse
 from yelp_bytes import to_bytes
 
@@ -171,7 +172,9 @@ class FidoFutureAdapter(FutureAdapter):
     retrieve results.
     """
 
-    timeout_errors = [fido.exceptions.HTTPTimeoutError]
+    timeout_errors = (fido.exceptions.HTTPTimeoutError,
+                      twisted.internet.error.DNSLookupError,
+                      twisted.internet.error.ConnectingCancelledError,)
 
     def __init__(self, eventual_result):
         self._eventual_result = eventual_result


### PR DESCRIPTION
This fixes #344 by adding twisted.internet.error.DNSLookupError and twisted.internet.error.ConnectingCancelledError to the list of timeout errors.

As mentioned in the issues, these seem like more general than just timeouts, but I can reliably reproduce them by setting low request timeouts, so they should probably be caught somehow.