### PR TITLE
Add integration tests for handling of query and path params with special chars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "Programming Language :: Python :: 3.6",
     ],
     install_requires=[
-        "bravado-core >= 4.11.0",
+        "bravado-core >= 4.11.4",
         "msgpack-python",
         "python-dateutil",
         "pyyaml",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -56,8 +56,55 @@ SWAGGER_SPEC_DICT = {
                     }
                 }
             }
-        }
-    }
+        },
+        '/echo': {
+            'get': {
+                'produces': ['application/json'],
+                'parameters': [
+                    {
+                        'in': 'query',
+                        'name': 'message',
+                        'type': 'string',
+                        'required': True,
+                    }
+                ],
+                'responses': {
+                    '200': {
+                        'description': 'HTTP/200',
+                        'schema': {
+                            'type': 'object',
+                            'properties': {
+                                'message': {
+                                    'type': 'string',
+                                },
+                            },
+                            'required': ['message'],
+                        },
+                    },
+                },
+            },
+        },
+        '/char_test/{special}': {
+            'get': {
+                'operationId': 'get_char_test',
+                'produces': ['application/json'],
+                'parameters': [
+                    {
+                        'in': 'path',
+                        'name': 'special',
+                        'type': 'string',
+                        'required': True,
+                    }
+                ],
+                'responses': {
+                    '200': {
+                        'description': 'HTTP/200',
+                        'schema': {'$ref': '#/definitions/api_response'},
+                    },
+                },
+            },
+        },
+    },
 }
 
 
@@ -95,6 +142,18 @@ def two():
 def double():
     x = bottle.request.params['number']
     return str(int(x) * 2)
+
+
+@bottle.get('/echo')
+def echo():
+    bottle.response.content_type = APP_JSON
+    return {'message': bottle.request.params['message']}
+
+
+@bottle.get('/char_test/spe%ial?')
+def char_test():
+    bottle.response.content_type = APP_JSON
+    return API_RESPONSE
 
 
 @bottle.get('/sleep')

--- a/tests/integration/requests_client_test.py
+++ b/tests/integration/requests_client_test.py
@@ -75,6 +75,15 @@ class TestServerRequestsClient:
         assert marshaled_response == API_RESPONSE
         assert raw_response.raw_bytes == packb(API_RESPONSE)
 
+    def test_swagger_client_special_chars_query(self, swagger_client):
+        message = 'My Me$$age with %pecial characters?"'
+        marshaled_response, _ = swagger_client.echo.get_echo(message=message).result(timeout=1)
+        assert marshaled_response == {'message': message}
+
+    def test_swagger_client_special_chars_path(self, swagger_client):
+        marshaled_response, _ = swagger_client.char_test.get_char_test(special='spe%ial?').result(timeout=1)
+        assert marshaled_response == API_RESPONSE
+
     def test_multiple_requests(self, threaded_http_server):
         request_one_params = {
             'method': 'GET',


### PR DESCRIPTION
Integration tests that verify that query param handling is correct, and that path param handling is fixed (the test fails with bravado-core < 4.11.4).