### PR TITLE
Add integration tests for sanitized resource and param handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
+repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v0.7.1
+    sha: v1.2.0
     hooks:
     -   id: autopep8-wrapper
         args:
@@ -16,6 +17,6 @@
     -   id: requirements-txt-fixer
         files: requirements-dev.txt
 -   repo: git://github.com/asottile/reorder_python_imports
-    sha: v0.3.1
+    sha: v1.0.1
     hooks:
     -   id: reorder-python-imports

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,7 +45,7 @@ Changelog
 
 9.0.3 (2017-06-21)
 ------------------
-- When using the fido HTTP client and passing a timeout to ``result()``, make sure we throw a fido HTTPTimeoutError instead of a crochet TimeoutError when hitting the timeout. 
+- When using the fido HTTP client and passing a timeout to ``result()``, make sure we throw a fido HTTPTimeoutError instead of a crochet TimeoutError when hitting the timeout.
 
 9.0.2 (2017-06-12)
 ------------------
@@ -71,7 +71,7 @@ Changelog
 
 8.2.0 (2016-04-29)
 ------------------
-- Bravado compliant to Fido 3.0.0 
+- Bravado compliant to Fido 3.0.0
 - Dropped use of concurrent futures in favor of crochet EventualResult
 - Workaround for bypassing a unicode bug in python `requests` < 2.8.1
 

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Example with Basic Authentication
 
     from bravado.requests_client import RequestsClient
     from bravado.client import SwaggerClient
-    
+
     http_client = RequestsClient()
     http_client.set_basic_auth(
         'api.yourhost.com',
@@ -69,7 +69,7 @@ Example with Header Authentication
 
     from bravado.requests_client import RequestsClient
     from bravado.client import SwaggerClient
-    
+
     http_client = RequestsClient()
     http_client.set_api_key(
         'api.yourhost.com', 'token'

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -3,13 +3,13 @@ import sys
 from functools import wraps
 
 import six
-from msgpack import unpackb
 from bravado_core.content_type import APP_JSON
 from bravado_core.content_type import APP_MSGPACK
 from bravado_core.exception import MatchingResponseNotFound
 from bravado_core.response import get_response_spec
 from bravado_core.unmarshal import unmarshal_schema_object
 from bravado_core.validate import validate_schema_object
+from msgpack import unpackb
 
 from bravado.config_defaults import REQUEST_OPTIONS_DEFAULTS
 from bravado.exception import BravadoTimeoutError

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -155,4 +155,3 @@ is easily done via configuration to return a
     print http_response.headers
     print http_response.status_code
     print pet.name
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,7 @@ Features include:
 * Dynamically generated client - no code generation needed!
 
 * `Synchronous <http://docs.python-requests.org/en/latest/>`_ and `Asynchronous <https://github.com/Yelp/fido>`_ http clients out of the box.
- 
+
 * Strict validations to verify that your Swagger Schema is  `v2.0 <https://github.com/wordnik/swagger-spec/blob/master/versions/2.0.md/>`_ compatible.
 
 * HTTP request and response validation against your Swagger Schema.

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "Programming Language :: Python :: 3.6",
     ],
     install_requires=[
-        "bravado-core >= 4.11.4",
+        "bravado-core >= 4.12.1",
         "msgpack-python",
         "python-dateutil",
         "pyyaml",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,9 +5,9 @@ import time
 import bottle
 import ephemeral_port_reserve
 import pytest
-from msgpack import packb
 from bravado_core.content_type import APP_JSON
 from bravado_core.content_type import APP_MSGPACK
+from msgpack import packb
 from six.moves import urllib
 
 
@@ -48,7 +48,7 @@ SWAGGER_SPEC_DICT = {
                 'produces': [
                     'application/msgpack',
                     'application/json'
-                 ],
+                ],
                 'responses': {
                     '200': {
                         'description': 'HTTP/200',
@@ -92,6 +92,26 @@ SWAGGER_SPEC_DICT = {
                     {
                         'in': 'path',
                         'name': 'special',
+                        'type': 'string',
+                        'required': True,
+                    }
+                ],
+                'responses': {
+                    '200': {
+                        'description': 'HTTP/200',
+                        'schema': {'$ref': '#/definitions/api_response'},
+                    },
+                },
+            },
+        },
+        '/sanitize-test': {
+            'get': {
+                'operationId': 'get_sanitized_param',
+                'produces': ['application/json'],
+                'parameters': [
+                    {
+                        'in': 'header',
+                        'name': 'X-User-Id',
                         'type': 'string',
                         'required': True,
                     }
@@ -154,6 +174,14 @@ def echo():
 def char_test():
     bottle.response.content_type = APP_JSON
     return API_RESPONSE
+
+
+@bottle.get('/sanitize-test')
+def sanitize_test():
+    if bottle.request.headers.get('X-User-Id') == 'admin':
+        bottle.response.content_type = APP_JSON
+        return API_RESPONSE
+    return bottle.HTTPResponse(status=404)
 
 
 @bottle.get('/sleep')

--- a/tests/petstore/user/createUsersWithArrayInput_test.py
+++ b/tests/petstore/user/createUsersWithArrayInput_test.py
@@ -11,7 +11,7 @@ def test_200_success(petstore):
             password='letmein',
             phone='111-222-3333',
             userStatus=3,
-        ) for user_id in xrange(4)]
+        ) for user_id in range(4)]
 
     result = petstore.user.createUsersWithArrayInput(body=users).result()
     assert result is None

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35,py36}-{default,fido}, {py27,py35,py36}-fido-requests2dot7, flake8
+envlist = {py27,py35,py36}-{default,fido}, {py27,py35,py36}-fido-requests2dot7, flake8, pre-commit
 
 [testenv]
 deps =
@@ -19,8 +19,13 @@ commands =
     flake8 bravado tests
 
 [testenv:pre-commit]
+basepython = python2.7
 deps = pre-commit>=0.12.0
-commands = pre-commit {posargs}
+setenv =
+    LC_CTYPE=en_US.UTF-8
+commands =
+    pre-commit install --install-hooks
+    pre-commit {posargs:run --all-files}
 
 [testenv:cover]
 deps =


### PR DESCRIPTION
Sanitizing resource and param names was recently added to bravado-core, let's add integration tests for it. 

I'm also setting up pre-commit properly and running it as part of the test suite. Some changes in this PR are from pre-commit hooks.