### PR TITLE
Add fetch_link to make it much easier to follow linked URLs within an API

### DIFF
--- a/bravado/client.py
+++ b/bravado/client.py
@@ -72,6 +72,8 @@ class SwaggerClient(object):
     def __init__(self, swagger_spec, also_return_response=False):
         self.__also_return_response = also_return_response
         self.swagger_spec = swagger_spec
+        # provide a backref to the client from the spec
+        self.swagger_spec._client = self
 
     @classmethod
     def from_url(cls, spec_url, http_client=None, request_headers=None, config=None):
@@ -153,7 +155,7 @@ class SwaggerClient(object):
 
         # Find it in the resources, we could add a single dict to lookup
         # operationId since it is required to be unique across the spec
-        for resource in self.resources.values():
+        for resource in self.swagger_spec.resources.values():
             op = resource.operations.get(operation_id)
             if op:
                 return op

--- a/bravado/client.py
+++ b/bravado/client.py
@@ -148,6 +148,16 @@ class SwaggerClient(object):
         # execute a service call via the http_client.
         return ResourceDecorator(resource, self.__also_return_response)
 
+    def _get_operation(self, operation_id):
+        """ Find an operation by operationId """
+
+        # Find it in the resources, we could add a single dict to lookup
+        # operationId since it is required to be unique across the spec
+        for resource in self.resources.values():
+            op = resource.operations.get(operation_id)
+            if op:
+                return op
+
     def __repr__(self):
         return u"%s(%s)" % (self.__class__.__name__, self.swagger_spec.api_url)
 


### PR DESCRIPTION
This is an attempt at answering the question I had in #352

By simply adding `x-operationId: [linkedOperation]` in your spec to URLs that are returned from the API that are internal links, and adding `add_fetch_link: True` to your config, those URLs will be returned in the model as `FetchLink` objects that can be called to retrieve the named `[linkedOperation]' on the given URL (e.g. obtain the http_request on that url and operationId, as if a CallableOperation had been called).

I think this is fairly straightforward.  The only item I question is how I added the backref to `swagger_spec._client`, mainly so I could access my new SwaggerClient._get_operation from the context of http_future where it seems I only had access to the operation spec.  If there was some other way around this, please let me know.  Alternatively _get_operation could be added to bravado-core instead I suppose.  I just felt it was similar in vein to _get_resource that is in this module.

Without the new config option, there is no changed default behaviors.

I suppose I need to add some tests for this to be accepted, but figured I'd throw it out here to get some feedback.
