### PR TITLE
Implement the new HTTPFuture.response method with fallback results

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Example Usage
 
     from bravado.client import SwaggerClient
     client = SwaggerClient.from_url('http://petstore.swagger.io/v2/swagger.json')
-    pet = client.pet.getPetById(petId=42).result()
+    pet = client.pet.getPetById(petId=42).response().result
 
 Example with Basic Authentication
 ---------------------------------
@@ -60,7 +60,7 @@ Example with Basic Authentication
         'http://petstore.swagger.io/v2/swagger.json',
         http_client=http_client,
     )
-    pet = client.pet.getPetById(petId=42).result()
+    pet = client.pet.getPetById(petId=42).response().result
 
 Example with Header Authentication
 ----------------------------------
@@ -79,7 +79,7 @@ Example with Header Authentication
         'http://petstore.swagger.io/v2/swagger.json',
         http_client=http_client,
     )
-    pet = client.pet.getPetById(petId=42).result()
+    pet = client.pet.getPetById(petId=42).response().result
 
 Example with Fido Client (Async Http Client)
 --------------------------------------------
@@ -95,7 +95,7 @@ Example with Fido Client (Async Http Client)
         'http://petstore.swagger.io/v2/swagger.json',
         http_client=http_client,
     )
-    pet = client.pet.getPetById(petId=42).result()
+    pet = client.pet.getPetById(petId=42).response().result
 
 Documentation
 -------------

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -143,7 +143,7 @@ class HttpFuture(object):
     def result(self, timeout=None):
         """DEPRECATED: please use the `response()` method instead.
 
-        Blocking call to wait for the HTTP response.
+        Blocking call to wait for and return the unmarshalled swagger result.
 
         :param timeout: Number of seconds to wait for a response. Defaults to
             None which means wait indefinitely.

--- a/bravado/response.py
+++ b/bravado/response.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+
+class BravadoResponse(object):
+    def __init__(self, incoming_response, result):
+        self.incoming_response = incoming_response
+        self.result = result
+        self.response_metadata = BravadoResponseMetadata(
+            incoming_response=self.incoming_response,
+            swagger_result=self.result,
+        )
+
+
+class BravadoResponseMetadata(object):
+    def __init__(self, incoming_response, swagger_result):
+        self.incoming_response = incoming_response
+        self.swagger_result = swagger_result

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -11,7 +11,7 @@ Validation example:
 .. code-block:: python
 
     pet = Pet(id="I should be integer :(", name="tommy")
-    client.pet.addPet(body=pet).result()
+    client.pet.addPet(body=pet).response().result
 
 will result in an error like so:
 
@@ -38,7 +38,7 @@ Adding Request Headers
     swagger_client.pet.addPet(
         body=pet,
         _request_options={"headers": {"foo": "bar"}},
-    ).result()
+    ).response().result
 
 
 Docstrings
@@ -139,7 +139,7 @@ The default behavior for a service call is to return the swagger result like so:
 
 .. code-block:: python
 
-    pet = petstore.pet.getPetById(petId=42).result()
+    pet = petstore.pet.getPetById(petId=42).response().result
     print pet.name
 
 However, there are times when it is necessary to have access to the actual
@@ -150,7 +150,7 @@ is easily done via configuration to return a
 .. code-block:: python
 
     petstore = Swagger.from_url(..., config={'also_return_response': True})
-    pet, http_response = petstore.pet.getPetById(petId=42).result()
+    pet, http_response = petstore.pet.getPetById(petId=42).response().result
     assert isinstance(http_response, bravado_core.response.IncomingResponse)
     print http_response.headers
     print http_response.status_code

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -50,7 +50,8 @@ Config key                Type            Default    Description
                                                      | Specifically, the return value of ``HttpFuture.result()``.
                                                      | When ``False``, the swagger result is returned.
                                                      | When ``True``, the tuple ``(swagger result, http response)``
-                                                     | is returned.
+                                                     | is returned. Has no effect on the return value of
+                                                     | ``HttpFuture.response()``.
                                                      | See :ref:`getting_access_to_the_http_response`.
 ========================= =============== =========  ===============================================================
 
@@ -63,7 +64,7 @@ Configuration can also be applied on a per-request basis by passing in
 
     client = SwaggerClient.from_url(...)
     request_options = { ... }
-    client.pet.getPetById(petId=42, _request_options=request_options).result()
+    client.pet.getPetById(petId=42, _request_options=request_options).response().result
 
 ========================= =============== =========  ===============================================================
 Config key                Type            Default    Description

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -22,7 +22,7 @@ Here is a simple example to try from a REPL (like IPython):
     from bravado.client import SwaggerClient
 
     client = SwaggerClient.from_url("http://petstore.swagger.io/v2/swagger.json")
-    pet = client.pet.getPetById(petId=42).result()
+    pet = client.pet.getPetById(petId=42).response().result
 
 If you were lucky, and pet Id with 42 was present, you will get back a result.
 It will be a dynamically created instance of ``bravado.model.Pet`` with attributes ``category``, etc. You can even try ``pet.category.id`` or ``pet.tags[0]``.
@@ -44,7 +44,7 @@ Here we will demonstrate how ``bravado`` hides all the ``JSON`` handling from th
         Pet = client.get_model('Pet')
         Category = client.get_model('Category')
         pet = Pet(id=42, name="tommy", category=Category(id=24))
-        client.pet.addPet(body=pet).result()
+        client.pet.addPet(body=pet).response().result
 
 
 Time to get Twisted! (Asynchronous client)

--- a/tests/integration/requests_client_test.py
+++ b/tests/integration/requests_client_test.py
@@ -57,50 +57,74 @@ class TestServerRequestsClient:
             config={'use_models': False, 'also_return_response': True}
         )
 
-    def test_swagger_client_json_response(self, swagger_client):
-        marshaled_response, raw_response = swagger_client.json.get_json().result(timeout=1)
+    @pytest.fixture(params=['result', 'response'])
+    def result_getter(self, request):
+        if request.param == 'result':
+            return lambda future, timeout: future.result(timeout)
+        elif request.param == 'response':
+            def _response_getter(future, timeout):
+                response = future.response(timeout)
+                return response.result, response.incoming_response
+            return _response_getter
+
+        raise ValueError
+
+    def test_swagger_client_json_response(self, swagger_client, result_getter):
+        marshaled_response, raw_response = result_getter(swagger_client.json.get_json(), timeout=1)
         assert marshaled_response == API_RESPONSE
         assert raw_response.raw_bytes == json.dumps(API_RESPONSE).encode('utf-8')
 
-    def test_swagger_client_msgpack_response_without_flag(self, swagger_client):
-        marshaled_response, raw_response = swagger_client.json_or_msgpack.get_json_or_msgpack().result(timeout=1)
+    def test_swagger_client_msgpack_response_without_flag(self, swagger_client, result_getter):
+        marshaled_response, raw_response = result_getter(
+            swagger_client.json_or_msgpack.get_json_or_msgpack(),
+            timeout=1,
+        )
         assert marshaled_response == API_RESPONSE
         assert raw_response.raw_bytes == json.dumps(API_RESPONSE).encode('utf-8')
 
-    def test_swagger_client_msgpack_response_with_flag(self, swagger_client):
-        marshaled_response, raw_response = swagger_client.json_or_msgpack.get_json_or_msgpack(
-            _request_options={
-                'use_msgpack': True,
-            },
-        ).result(timeout=1)
+    def test_swagger_client_msgpack_response_with_flag(self, swagger_client, result_getter):
+        marshaled_response, raw_response = result_getter(
+            swagger_client.json_or_msgpack.get_json_or_msgpack(
+                _request_options={
+                    'use_msgpack': True,
+                },
+            ),
+            timeout=1,
+        )
         assert marshaled_response == API_RESPONSE
         assert raw_response.raw_bytes == packb(API_RESPONSE)
 
-    def test_swagger_client_special_chars_query(self, swagger_client):
+    def test_swagger_client_special_chars_query(self, swagger_client, result_getter):
         message = 'My Me$$age with %pecial characters?"'
-        marshaled_response, _ = swagger_client.echo.get_echo(message=message).result(timeout=1)
+        marshaled_response, _ = result_getter(swagger_client.echo.get_echo(message=message), timeout=1)
         assert marshaled_response == {'message': message}
 
-    def test_swagger_client_special_chars_path(self, swagger_client):
-        marshaled_response, _ = swagger_client.char_test.get_char_test(special='spe%ial?').result(timeout=1)
+    def test_swagger_client_special_chars_path(self, swagger_client, result_getter):
+        marshaled_response, _ = result_getter(swagger_client.char_test.get_char_test(special='spe%ial?'), timeout=1)
         assert marshaled_response == API_RESPONSE
 
-    def test_sanitized_resource_and_param(self, swagger_client):
-        marshaled_response, _ = swagger_client.sanitize_test.get_sanitized_param(X_User_Id='admin').result(timeout=1)
+    def test_sanitized_resource_and_param(self, swagger_client, result_getter):
+        marshaled_response, _ = result_getter(
+            swagger_client.sanitize_test.get_sanitized_param(X_User_Id='admin'),
+            timeout=1,
+        )
         assert marshaled_response == API_RESPONSE
 
-    def test_unsanitized_resource_and_param(self, swagger_client):
+    def test_unsanitized_resource_and_param(self, swagger_client, result_getter):
         params = {'X-User-Id': 'admin'}
-        marshaled_response, _ = swagger_client._get_resource(
-            'sanitize-test',
-        ).get_sanitized_param(**params).result(timeout=1)
+        marshaled_response, _ = result_getter(
+            swagger_client._get_resource(
+                'sanitize-test',
+            ).get_sanitized_param(**params),
+            timeout=1,
+        )
         assert marshaled_response == API_RESPONSE
 
-    def test_unsanitized_param_as_header(self, swagger_client):
+    def test_unsanitized_param_as_header(self, swagger_client, result_getter):
         headers = {'X-User-Id': 'admin'}
-        marshaled_response, _ = swagger_client.sanitize_test.get_sanitized_param(
+        marshaled_response, _ = result_getter(swagger_client.sanitize_test.get_sanitized_param(
             _request_options={'headers': headers},
-        ).result(timeout=1)
+        ), timeout=1)
         assert marshaled_response == API_RESPONSE
 
     def test_multiple_requests(self, threaded_http_server):


### PR DESCRIPTION
This is a first rough PR so people get the idea. I just modified a few integration tests to showcase that the implementation works (at least as far as replacing calls to `result()` goes).

I'll add more tests tomorrow unless we decide on going a different route. I'm also more than prepared to change names if you have better suggestions. :)