### PR TITLE
Attempt to have more stable tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 
   - env: TOXENV=cover
   - env: TOXENV=docs
-  - env: TOXENV=flake8
+  - env: TOXENV=pre-commit
 
 install:
 - "pip install tox coveralls"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-from multiprocessing import Process
 import time
+from multiprocessing import Process
 
 import bottle
 import ephemeral_port_reserve
 import pytest
+import requests
 from bravado_core.content_type import APP_JSON
 from bravado_core.content_type import APP_MSGPACK
 from msgpack import packb
-import requests
 
 
 ROUTE_1_RESPONSE = b'HEY BUDDY'


### PR DESCRIPTION
From time to time bravado integration tests fails due to not graceful terminations of the thread running bottle service.
In order to make tests more stable (as failures were not related to what we were actually testing) I'm proposing to switch to use bottle on its own separate process.

As additional point I modified travis to run pre-commit hooks instead of flake8 only during tests