### PR TITLE
Fix swaggerpy build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 matrix:
   include:
-    - env: TOXENV=py26
-      python: "2.6"
     - env: TOXENV=py27
     - env: TOXENV=py34
     - env: TOXENV=cover

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,4 @@ setup(
         'yelp_bytes',
         "yelp_uri >= 1.0.1",
     ],
-    extras_require={
-        ':python_version=="2.6"': ['twisted >= 14.0.0, < 15.5'],
-        ':python_version!="2.6"': ['twisted >= 14.0.0'],
-    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py35, flake8
+envlist = py27, py35, flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
It's quite some time that swaggerpy build is failing on travis.
As the build is failing for py26 only I've opted for removing python 2.6 instead of finding the root cause