### PR TITLE
We require at least requests 2.4 for requests.exceptions.ReadTimeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "msgpack-python",
         "python-dateutil",
         "pyyaml",
-        "requests >= 2",
+        "requests >= 2.4",
         "six",
     ],
     extras_require={


### PR DESCRIPTION
This fixes Yelp/bravado-core#271.