### PR TITLE
Change some metadata names, fix a potential Python 2 memory leak

### DIFF
--- a/bravado/response.py
+++ b/bravado/response.py
@@ -8,13 +8,13 @@ class BravadoResponse(object):
     use at your own risk.
     """
 
-    def __init__(self, result, response_metadata):
+    def __init__(self, result, metadata):
         self.result = result
-        self.response_metadata = response_metadata
+        self.metadata = metadata
 
     @property
     def incoming_response(self):
-        return self.response_metadata.incoming_response
+        return self.metadata.incoming_response
 
 
 class BravadoResponseMetadata(object):
@@ -29,10 +29,17 @@ class BravadoResponseMetadata(object):
     use at your own risk.
     """
 
-    def __init__(self, incoming_response, swagger_result, elapsed_time, exc_info):
+    def __init__(self, incoming_response, swagger_result, elapsed_time, handled_exception_info):
+        """
+        :param incoming_response: a subclass of bravado_core.response.IncomingResponse.
+        :param swagger_result: the unmarshalled result that is being returned to the user.
+        :param elapsed_time: float containing an approximate elapsed time since creating the future, in seconds.
+        :param handled_exception_info: sys.exc_info() data if an exception was caught and handled as
+            part of a fallback response.
+        """
         self._incoming_response = incoming_response
         self.elapsed_time = elapsed_time
-        self.exc_info = exc_info
+        self.handled_exception_info = handled_exception_info
 
         # we expose the result to the user through the BravadoResponse object;
         # we're passing it in to this object in case custom implementations need it
@@ -54,4 +61,4 @@ class BravadoResponseMetadata(object):
 
     @property
     def is_fallback_result(self):
-        return self.exc_info is not None
+        return self.handled_exception_info is not None

--- a/bravado/response.py
+++ b/bravado/response.py
@@ -35,7 +35,8 @@ class BravadoResponseMetadata(object):
         :param swagger_result: the unmarshalled result that is being returned to the user.
         :param elapsed_time: float containing an approximate elapsed time since creating the future, in seconds.
         :param handled_exception_info: sys.exc_info() data if an exception was caught and handled as
-            part of a fallback response.
+            part of a fallback response; note that the third element in the list is a string representation
+            of the traceback, not a traceback object.
         """
         self._incoming_response = incoming_response
         self.elapsed_time = elapsed_time

--- a/tests/http_future/HttpFuture/response_test.py
+++ b/tests/http_future/HttpFuture/response_test.py
@@ -39,8 +39,8 @@ def test_fallback_result(mock_future_adapter, mock_operation, http_future):
     response = http_future.response(fallback_result=lambda e: fallback_result)
 
     assert response.result == fallback_result
-    assert response.response_metadata.is_fallback_result is True
-    assert response.response_metadata.exc_info[0] is BravadoTimeoutError
+    assert response.metadata.is_fallback_result is True
+    assert response.metadata.handled_exception_info[0] is BravadoTimeoutError
 
 
 def test_no_fallback_result_if_not_provided(mock_future_adapter, http_future):
@@ -68,4 +68,4 @@ def test_custom_response_metadata(mock_operation, http_future):
 
     with mock.patch('bravado.http_future.unmarshal_response'):
         response = http_future.response()
-    assert response.response_metadata.__class__ is ResponseMetadata
+    assert response.metadata.__class__ is ResponseMetadata


### PR DESCRIPTION
Are we ok with these new names?

See https://docs.python.org/2/library/sys.html#sys.exc_info for the other part.