### PR TITLE
Validate and unmarshal the fallback result

### DIFF
--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -18,6 +18,7 @@ from bravado.exception import BravadoTimeoutError
 from bravado.exception import HTTPServerError
 from bravado.exception import make_http_exception
 from bravado.response import BravadoResponse
+from bravado.response import FallbackIncomingResponse
 
 
 FALLBACK_EXCEPTIONS = (
@@ -151,7 +152,8 @@ class HttpFuture(object):
                 fallback_result and self.operation
                 and not self.operation.swagger_spec.config['bravado'].disable_fallback_results
             ):
-                swagger_result = fallback_result(e)
+                # unmarshal and validate the fallback result
+                swagger_result = self._get_swagger_result(FallbackIncomingResponse(fallback_result(e)))
             else:
                 six.reraise(*sys.exc_info())
 

--- a/bravado/response.py
+++ b/bravado/response.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import monotonic
+from bravado_core.content_type import APP_JSON
+from bravado_core.response import IncomingResponse
 
 
 class BravadoResponse(object):
@@ -78,3 +80,19 @@ class BravadoResponseMetadata(object):
     @property
     def elapsed_time(self):
         return self.processing_end_time - self.start_time
+
+
+class FallbackIncomingResponse(IncomingResponse):
+    """An IncomingResponse implementation that contains a fallback result to be returned; we're using it
+    so that we can unmarshal (and potentially validate) the response the user provided."""
+
+    def __init__(self, result, status_code=200):
+        self._result = result
+        self.status_code = status_code
+
+    @property
+    def headers(self):
+        return {'content-type': APP_JSON}
+
+    def json(self):
+        return self._result


### PR DESCRIPTION
This changes the expected fallback result value to be a Python representation of the wire data, which I think is more intuitive to use. The change also causes response validation to run for the fallback result data, which could help in catching errors.

On the other hand, it potentially makes testing this case harder, as we can't just mock BravadoResponse.result to return whatever the fallback_result callback returns - unmarshalling needs to occur for it to be correct. Thoughts?