### PR TITLE
Prevent usage of httpretty==0.9.5 to fix coverge tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 bottle
-httpretty
+# httpretty 0.9.5 introduces issues while testing with python 2.7 (https://github.com/gabrielfalcao/HTTPretty/issues/340)
+httpretty!=0.9.5
 mock==1.3
 ordereddict
 pre-commit


### PR DESCRIPTION
Latest release of httpretty (0.9.5) is causing coverage tests failures.
Example of failure: https://travis-ci.org/Yelp/bravado/jobs/389710565

As temporary workaround I'm forcing not using that specific version as an issue on httpretty has already been opened (https://github.com/gabrielfalcao/HTTPretty/issues/340)
