### PR TITLE
Improve documentation generation, add docs for usage and response

### DIFF
--- a/bravado/response.py
+++ b/bravado/response.py
@@ -7,6 +7,9 @@ class BravadoResponse(object):
 
     WARNING: This interface is considered UNSTABLE. Backwards-incompatible API changes may occur;
     use at your own risk.
+
+    :ivar result: Swagger result from the server
+    :ivar BravadoResponseMetadata metadata: metadata for this response including HTTP response
     """
 
     def __init__(self, result, metadata):
@@ -28,6 +31,12 @@ class BravadoResponseMetadata(object):
 
     WARNING: This interface is considered UNSTABLE. Backwards-incompatible API changes may occur;
     use at your own risk.
+
+    :ivar float start_time: monotonic timestamp at which the future was created
+    :ivar float request_end_time: monotonic timestamp at which we received the HTTP response
+    :ivar float processing_end_time: monotonic timestamp at which processing the response ended
+    :ivar tuple handled_exception_info: 3-tuple of exception class, exception instance and string
+        representation of the traceback in case an exception was caught during request processing.
     """
 
     def __init__(self, incoming_response, swagger_result, start_time, request_end_time, handled_exception_info):

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -236,3 +236,8 @@ of your properties, use :attr:`.BravadoResponseMetadata.headers` to access respo
 
 If, for some reason, you need your own ``__init__`` method, make sure you have the same signature
 as the base method and that you call it (the base method) from your own implementation.
+
+While developing custom :class:`.BravadoResponseMetadata` classes we recommend to avoid,
+if possible, the usage of attributes for data that's expensive to compute. Since the object
+will be created for every response, implementing these fields as properties makes sure
+the evaluation is only done if the field is accessed.

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -178,6 +178,7 @@ to that response, like the HTTP status code.
 In the simplest case, you can just specify what you're going to return:
 
 .. code-block:: python
+
     petstore = Swagger.from_url('http://petstore.swagger.io/swagger.json')
     response = petstore.pet.findPetsByStatus(status=['available']).response(
         timeout=0.5,
@@ -185,13 +186,26 @@ In the simplest case, you can just specify what you're going to return:
     )
 
 This code will return an empty list in case the server doesn't respond quickly enough (or it
-responded quickly enough, but returned an error). See :mod:`bravado.exception` for a list of
-possible exception types.
+responded quickly enough, but returned an error).
+
+Customizing which error types to handle
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, the fallback result will be used either when the server doesn't send the response
+in time or when it returns a server error (i.e. a result with a HTTP 5XX status code). To override this behavior,
+specify the ``exceptions_to_catch`` argument to :meth:`.HttpFuture.response`.
+
+The default is defined in :data:`bravado.http_future.FALLBACK_EXCEPTIONS`. See
+:mod:`bravado.exception` for a list of possible exception types.
+
+Models and fallback results
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 But what if you're using models (the default) and the endpoint you're calling returns one? You'll have
 to return one as well from your fallback_result function to stay compatible with the rest of your code:
 
 .. code-block:: python
+
     petstore = Swagger.from_url('http://petstore.swagger.io/swagger.json')
     response = petstore.pet.getPetById(petId=101).response(
         timeout=0.5,

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -172,8 +172,8 @@ provided by :meth:`.HttpFuture.response`.
 :meth:`.HttpFuture.response` takes an optional argument ``fallback_result`` which is a callable
 that returns a Swagger result. The callable takes one mandatory argument: the exception that would
 have been raised normally. This allows you to return different results based on the type of error
-(e.g. a :class:`.BravadoTimeoutError`) or, if a server response was received, on the type of HTTP
-code.
+(e.g. a :class:`.BravadoTimeoutError`) or, if a server response was received, on any data pertaining
+to that response, like the HTTP status code.
 
 In the simplest case, you can just specify what you're going to return:
 
@@ -199,7 +199,8 @@ to return one as well from your fallback_result function to stay compatible with
 
 Two things to note here: first, use :meth:`.SwaggerClient.get_model` to get the model class for a
 model name. Second, since ``name`` and ``photoUrls`` are required fields for this model, we probably should not leave them
-empty (they'll be accessible, but ``None``). It's up to you how you decide to deal with this case.
+empty (if we do they'd still be accessible, but the value would be ``None``). It's up to you how you decide to deal
+with this case.
 
 :attr:`.BravadoResponseMetadata.is_fallback_result` will be True if a fallback result has been returned
 by the call to :meth:`.HttpFuture.response`.

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -143,15 +143,80 @@ The default behavior for a service call is to return the swagger result like so:
     print pet.name
 
 However, there are times when it is necessary to have access to the actual
-HTTP response so that the HTTP headers or HTTP status code can be used. This
-is easily done via configuration to return a
-``(swagger result, http response)`` tuple from the service call.
+HTTP response so that the HTTP headers or HTTP status code can be used. Simply save
+the response object (which is a :class:`.BravadoResponse`) and use its ``incoming_response``
+attribute to access the incoming response:
 
 .. code-block:: python
 
-    petstore = Swagger.from_url(..., config={'also_return_response': True})
-    pet, http_response = petstore.pet.getPetById(petId=42).response().result
+    petstore = Swagger.from_url(
+        'http://petstore.swagger.io/swagger.json',
+        config={'also_return_response': True},
+    )
+    pet_response = petstore.pet.getPetById(petId=42).response()
+    http_response = pet_response.incoming_response
     assert isinstance(http_response, bravado_core.response.IncomingResponse)
     print http_response.headers
     print http_response.status_code
     print pet.name
+
+.. _fallback_results:
+
+Working with fallback results
+-----------------------------
+
+By default, if the server returns an error or doesn't respond in time, you have to catch and handle
+the resulting exception accordingly. A simpler way would be to use the support for fallback results
+provided by :meth:`.HttpFuture.response`.
+
+:meth:`.HttpFuture.response` takes an optional argument ``fallback_result`` which is a callable
+that returns a Swagger result. The callable takes one mandatory argument: the exception that would
+have been raised normally. This allows you to return different results based on the type of error
+(e.g. a :class:`.BravadoTimeoutError`) or, if a server response was received, on the type of HTTP
+code.
+
+In the simplest case, you can just specify what you're going to return:
+
+.. code-block:: python
+    petstore = Swagger.from_url('http://petstore.swagger.io/swagger.json')
+    response = petstore.pet.findPetsByStatus(status=['available']).response(
+        timeout=0.5,
+        fallback_result=lambda e: [],
+    )
+
+This code will return an empty list in case the server doesn't respond quickly enough (or it
+responded quickly enough, but returned an error).
+
+But what if you're using models (the default) and the endpoint you're calling returns one? You'll have
+to return one as well from your fallback_result function to stay compatible with the rest of your code:
+
+.. code-block:: python
+    petstore = Swagger.from_url('http://petstore.swagger.io/swagger.json')
+    response = petstore.pet.getPetById(petId=101).response(
+        timeout=0.5,
+        fallback_result=lambda e: petstore.get_model('Pet')(name='No Pet found', photoUrls=[]),
+    )
+
+Two things to note here: first, use :meth:`.SwaggerClient.get_model` to get the model class for a
+model name. Second, since ``name`` and ``photoUrls`` are required fields for this model, we probably should not leave them
+empty (they'll be accessible, but ``None``). It's up to you how you decide to deal with this case.
+
+:attr:`.BravadoResponseMetadata.is_fallback_result` will be True if a fallback result has been returned
+by the call to :meth:`.HttpFuture.response`.
+
+.. _custom_response_metadata:
+
+Custom response metadata
+------------------------
+
+Sometimes, there's additional metadata in the response that you'd like to make available easily.
+This case arises most often if you're using bravado to talk to internal services. Maybe you have
+special HTTP headers that indicate whether a circuit breaker was triggered? bravado allows you to
+customize the metadata and provide custom attributes and methods.
+
+In your code, create a class that subclasses :class:`bravado.response.BravadoResponseMetadata`. In the implementation
+of your properties, use :attr:`.BravadoResponseMetadata.headers` to access response headers, or
+:attr:`.BravadoResponseMetadata.incoming_response` to access any other part of the HTTP response.
+
+If, for some reason, you need your own ``__init__`` method, make sure you have the same signature
+as the base method and that you call it (the base method) from your own implementation.

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -185,7 +185,8 @@ In the simplest case, you can just specify what you're going to return:
     )
 
 This code will return an empty list in case the server doesn't respond quickly enough (or it
-responded quickly enough, but returned an error).
+responded quickly enough, but returned an error). See :mod:`bravado.exception` for a list of
+possible exception types.
 
 But what if you're using models (the default) and the endpoint you're calling returns one? You'll have
 to return one as well from your fallback_result function to stay compatible with the rest of your code:

--- a/docs/source/bravado.rst
+++ b/docs/source/bravado.rst
@@ -1,6 +1,10 @@
 bravado Package
 ===============
 
+.. toctree::
+   :maxdepth: 4
+
+
 :mod:`bravado` Package
 ----------------------
 
@@ -8,6 +12,14 @@ bravado Package
 --------------------
 
 .. automodule:: bravado.client
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+:mod:`config` Module
+--------------------
+
+.. automodule:: bravado.config
     :members:
     :undoc-members:
     :show-inheritance:
@@ -32,6 +44,14 @@ bravado Package
 -------------------------
 
 .. automodule:: bravado.http_future
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+:mod:`response` Module
+-------------------------
+
+.. automodule:: bravado.response
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -18,18 +18,25 @@ is available too.
     config = {
         # === bravado config ===
 
-        # Determines what is returned by the service call.
+        # What class to use for response metadata
+        'response_metadata_class': 'bravado.response.BravadoResponseMetadata',
+
+        # Do not use fallback results even if they're provided
+        'disable_fallback_results': False,
+
+        # DEPRECATED: Determines what is returned by HttpFuture.result().
+        # Please use HttpFuture.response() for accessing the http response.
         'also_return_response': False,
 
         # === bravado-core config ====
 
-        #  validate incoming responses
+        # Validate incoming responses
         'validate_responses': True,
 
-        # validate outgoing requests
+        # Validate outgoing requests
         'validate_requests': True,
 
-        # validate the swagger spec
+        # Validate the swagger spec
         'validate_swagger_spec': True,
 
         # Use models (Python classes) instead of dicts for #/definitions/{models}
@@ -43,17 +50,25 @@ is available too.
     client = SwaggerClient.from_url(..., config=config)
 
 
-========================= =============== =========  ===============================================================
-Config key                Type            Default    Description
-------------------------- --------------- ---------  ---------------------------------------------------------------
-*also_return_response*    boolean         False      | Determines what is returned by the service call.
-                                                     | Specifically, the return value of ``HttpFuture.result()``.
-                                                     | When ``False``, the swagger result is returned.
-                                                     | When ``True``, the tuple ``(swagger result, http response)``
-                                                     | is returned. Has no effect on the return value of
-                                                     | ``HttpFuture.response()``.
-                                                     | See :ref:`getting_access_to_the_http_response`.
-========================= =============== =========  ===============================================================
+========================== =============== ===============================================================
+Config key                 Type            Description
+-------------------------- --------------- ---------------------------------------------------------------
+*response_metadata_class*  string          | The Metadata class to use; see
+                                           | :ref:`custom_response_metadata` for details.
+                                           Default: :class:`bravado.response.BravadoResponseMetadata`
+*disable_fallback_results* boolean         | Whether to disable returning fallback results, even if
+                                           | they're provided as an argument to
+                                           | to :meth:`.HttpFuture.response`.
+                                           Default: ``False``
+*also_return_response*     boolean         | Determines what is returned by the service call.
+                                           | Specifically, the return value of :meth:`.HttpFuture.result`.
+                                           | When ``False``, the swagger result is returned.
+                                           | When ``True``, the tuple ``(swagger result, http response)``
+                                           | is returned. Has no effect on the return value of
+                                           | :meth:`.HttpFuture.response`.
+                                           | See :ref:`getting_access_to_the_http_response`.
+                                           Default: ``False``
+========================== =============== ===============================================================
 
 Per-request Configuration
 --------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,7 +31,9 @@ Contents:
 
    quickstart
    configuration
+   requests_and_responses
    advanced
+   modules
    changelog
 
 Indices and tables

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,5 +1,5 @@
-bravado
-=======
+API reference
+=============
 
 .. toctree::
    :maxdepth: 4

--- a/docs/source/requests_and_responses.rst
+++ b/docs/source/requests_and_responses.rst
@@ -1,0 +1,59 @@
+Making requests with bravado
+============================
+
+When you call :meth:`.SwaggerClient.from_url` or :meth:`.SwaggerClient.from_spec`, Bravado takes a
+Swagger (OpenAPI) 2.0 spec and returns a :class:`.SwaggerClient` instance that you can use to make
+calls to the service described in the spec. You make calls by doing Python method calls in the form
+of ``client.resource.operation(operation_params)``. Use ``dir(client)`` to see all available resources.
+
+Resources and operations
+------------------------
+
+Resources are generated for each tag that exists in your Swagger spec. If an operation has no tags then
+the left-most element of its path is taken as resource name. So in the case of an operation with the
+path ``/pet/find``, ``pet`` will be the resource.
+
+The operation name will be the (:ref:`sanitized <sanitizing_names>`) operationId value from the Swagger spec. If there is no
+operationId, it will be generated. We highly recommend providing operation IDs for all operations.
+Use ``dir(client.resource)`` to see a list of all available operations.
+
+The operation method expects keyword arguments that have the same (:ref:`sanitized <sanitizing_names>`) names as in the Swagger spec.
+Use corresponding Python types for the values - if the Swagger spec says a parameter is of type ``boolean``,
+provide it as a Python ``bool``.
+
+Futures and responses
+---------------------
+
+The return value of the operation method is a :class:`.HttpFuture`. To access the response, call :meth:`.HttpFuture.response()`.
+This call will block, i.e. it will wait until the response is received or the timeout you specified is reached.
+
+If the request succeeded and the server returned a HTTP status code between 200 and 399, the return value of
+:meth:`.HttpFuture.response()` will be a :class:`~bravado.response.BravadoResponse` instance. You may access the Swagger
+result of your call through :attr:`.BravadoResponse.result`.
+
+If the server sent a response with a HTTP code of 400 or higher, by default a subclass of :class:`.HTTPError` will be raised
+when you call :meth:`.HttpFuture.response`. The exception gives you access to the Swagger result (:attr:`.HTTPError.swagger_result`)
+as well as the HTTP response object (:attr:`.HTTPError.response`).
+
+Response metadata
+-----------------
+
+:attr:`.BravadoResponse.metadata` is an instance of :class:`.BravadoResponseMetadata` that provides you with access
+to the HTTP response including headers and HTTP status code, request timings and whether a fallback result
+was used (see :ref:`fallback_results`).
+
+You're able to provide your own implementation of :class:`.BravadoResponseMetadata`; see :ref:`custom_response_metadata` for details.
+
+.. _sanitizing_names:
+
+Sanitizing names
+----------------
+
+Not all characters that the Swagger spec allows for names are valid Python identifiers. In particular,
+spaces and the ``-`` character can be troublesome. bravado sanitizes resource, operation and parameter names
+according to these rules:
+
+- Any character that is not a letter or number is converted to an underscore (``_``)
+- Collapse multiple consecutive underscores to one
+- Remove leading and trailing underscores
+- Remove leading numbers

--- a/docs/source/requests_and_responses.rst
+++ b/docs/source/requests_and_responses.rst
@@ -24,7 +24,7 @@ provide it as a Python ``bool``.
 Futures and responses
 ---------------------
 
-The return value of the operation method is a :class:`.HttpFuture`. To access the response, call :meth:`.HttpFuture.response()`.
+The return value of the operation method is a :class:`.HttpFuture`. To access the response, call :meth:`.HttpFuture.response`.
 This call will block, i.e. it will wait until the response is received or the timeout you specified is reached.
 
 If the request succeeded and the server returned a HTTP status code between 200 and 399, the return value of

--- a/docs/source/requests_and_responses.rst
+++ b/docs/source/requests_and_responses.rst
@@ -27,7 +27,7 @@ Futures and responses
 The return value of the operation method is a :class:`.HttpFuture`. To access the response, call :meth:`.HttpFuture.response`.
 This call will block, i.e. it will wait until the response is received or the timeout you specified is reached.
 
-If the request succeeded and the server returned a HTTP status code between 200 and 399, the return value of
+If the request succeeded and the server returned a HTTP status code between 100 and 299, the return value of
 :meth:`.HttpFuture.response()` will be a :class:`~bravado.response.BravadoResponse` instance. You may access the Swagger
 result of your call through :attr:`.BravadoResponse.result`.
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,10 +37,10 @@ commands =
     coverage report --omit=.tox/*,tests/*,/usr/share/pyshared/*,/usr/lib/pymodules/* -m
 
 [testenv:docs]
-skip_install = True
 deps =
     sphinx
     sphinx-rtd-theme
+    .[fido]
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html
 


### PR DESCRIPTION
Previously, sphinx wouldn't find the bravado modules, so referencing API documentation wouldn't work. This CR fixes it and adds more detailed documentation about how to make requests with bravado. It's also an attempt to start documenting the new `response` interface as well as the features it provides.