### PR TITLE
Introduce RequestConfig and a way to force returning fallback results

### DIFF
--- a/bravado/client.py
+++ b/bravado/client.py
@@ -54,7 +54,7 @@ from six import iteritems
 from six import itervalues
 
 from bravado.config import BravadoConfig
-from bravado.config import REQUEST_OPTIONS_DEFAULTS
+from bravado.config import RequestConfig
 from bravado.docstring_property import docstring_property
 from bravado.requests_client import RequestsClient
 from bravado.swagger_model import Loader
@@ -239,27 +239,20 @@ class CallableOperation(object):
         log.debug(u'%s(%s)', self.operation.operation_id, op_kwargs)
         warn_for_deprecated_op(self.operation)
 
-        # Apply request_options defaults
-        request_options = dict(
-            REQUEST_OPTIONS_DEFAULTS,
-            **(op_kwargs.pop('_request_options', {})))
+        # Get per-request config
+        request_options = op_kwargs.pop('_request_options', {})
+        request_config = RequestConfig.from_request_options_dict(request_options, self.also_return_response)
 
         request_params = construct_request(
             self.operation, request_options, **op_kwargs)
 
         http_client = self.operation.swagger_spec.http_client
 
-        # Per-request config overrides client wide config
-        also_return_response = request_options.get(
-            'also_return_response',
-            self.also_return_response,
-        )
-
         return http_client.request(
             request_params,
             operation=self.operation,
-            response_callbacks=request_options['response_callbacks'],
-            also_return_response=also_return_response)
+            request_config=request_config,
+        )
 
 
 def construct_request(operation, request_options, **op_kwargs):

--- a/bravado/client.py
+++ b/bravado/client.py
@@ -241,7 +241,7 @@ class CallableOperation(object):
 
         # Get per-request config
         request_options = op_kwargs.pop('_request_options', {})
-        request_config = RequestConfig.from_request_options_dict(request_options, self.also_return_response)
+        request_config = RequestConfig(request_options, self.also_return_response)
 
         request_params = construct_request(
             self.operation, request_options, **op_kwargs)

--- a/bravado/config.py
+++ b/bravado/config.py
@@ -29,6 +29,7 @@ REQUEST_OPTIONS_DEFAULTS = {
     #   param : operation
     #   type  : class:`bravado_core.operation.Operation`
     'response_callbacks': [],
+    'force_fallback_result': False,
 }
 
 
@@ -50,6 +51,33 @@ class BravadoConfig(
         return BravadoConfig(
             **bravado_config
         )
+
+
+class RequestConfig(
+    namedtuple(
+        'RequestConfig',
+        [
+            'also_return_response',
+            'force_fallback_result',
+            'response_callbacks',
+            # options used to construct the request params
+            'connect_timeout',
+            'headers',
+            'use_msgpack',
+            'timeout',
+        ]
+    )
+):
+    @staticmethod
+    def from_request_options_dict(request_options, also_return_response_default):
+        request_config = {
+            key: request_options.get(key, REQUEST_OPTIONS_DEFAULTS.get(key))
+            for key in RequestConfig._fields
+        }
+        if 'also_return_response' not in request_options:
+            request_config['also_return_response'] = also_return_response_default
+
+        return RequestConfig(**request_config)
 
 
 def _get_response_metadata_class(fully_qualified_class_str):

--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -334,3 +334,8 @@ class HTTPNetworkAuthenticationRequired(HTTPServerError):
 
 class BravadoTimeoutError(base_exception):
     pass
+
+
+class ForcedFallbackResultError(Exception):
+    """This exception will be handled if the option to force returning a fallback result
+     is used."""

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -72,8 +72,7 @@ class FidoClient(HttpClient):
     """Fido (Asynchronous) HTTP client implementation.
     """
 
-    def request(self, request_params, operation=None, response_callbacks=None,
-                also_return_response=False):
+    def request(self, request_params, operation=None, request_config=None):
         """Sets up the request params as per Twisted Agent needs.
         Sets up crochet and triggers the API request in background
 
@@ -83,10 +82,7 @@ class FidoClient(HttpClient):
             to None - in which case, we're obviously just retrieving a Swagger
             Spec.
         :type operation: :class:`bravado_core.operation.Operation`
-        :param response_callbacks: List of callables to post-process the
-            incoming response. Expects args incoming_response and operation.
-        :param also_return_response: Consult the constructor documentation for
-            :class:`bravado.http_future.HttpFuture`.
+        :param RequestConfig request_config: per-request configuration
 
         :rtype: :class: `bravado_core.http_future.HttpFuture`
         """
@@ -98,8 +94,7 @@ class FidoClient(HttpClient):
         return HttpFuture(future_adapter,
                           FidoResponseAdapter,
                           operation,
-                          response_callbacks,
-                          also_return_response)
+                          request_config)
 
     @staticmethod
     def prepare_request_for_twisted(request_params):

--- a/bravado/http_client.py
+++ b/bravado/http_client.py
@@ -8,8 +8,7 @@ class HttpClient(object):
     and perform HTTP calls to fulfill a Swagger operation.
     """
 
-    def request(self, request_params, operation=None, response_callbacks=None,
-                also_return_response=False):
+    def request(self, request_params, operation=None, request_config=None):
         """
         :param request_params: complete request data. e.g. url, method,
             headers, body, params, connect_timeout, timeout, etc.
@@ -18,9 +17,7 @@ class HttpClient(object):
             to None - in which case, we're obviously just retrieving a Swagger
             Spec.
         :type operation: :class:`bravado_core.operation.Operation`
-        :param response_callbacks: List of callables to post-process the
-            incoming response. Expects args incoming_response and operation.
-        :param also_return_response: Consult the constructor documentation for
+        :param RequestConfig request_config: Per-request config that is passed to
             :class:`bravado.http_future.HttpFuture`.
 
         :returns: HTTP Future object

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -140,6 +140,11 @@ class HttpFuture(object):
             incoming_response = self._get_incoming_response(timeout)
             request_end_time = monotonic.monotonic()
 
+            swagger_result = self._get_swagger_result(incoming_response)
+
+            if self.operation is None and incoming_response.status_code >= 300:
+                raise make_http_exception(response=incoming_response)
+
             # Trigger fallback_result if the option is set
             if fallback_result and self.request_config.force_fallback_result:
                 if self.operation.swagger_spec.config['bravado'].disable_fallback_results:
@@ -150,11 +155,6 @@ class HttpFuture(object):
                 else:
                     # raise an exception to trigger fallback result handling
                     raise ForcedFallbackResultError()
-
-            swagger_result = self._get_swagger_result(incoming_response)
-
-            if self.operation is None and incoming_response.status_code >= 300:
-                raise make_http_exception(response=incoming_response)
 
         except exceptions_to_catch as e:
             if request_end_time is None:

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 import sys
 import traceback
 from functools import wraps
@@ -13,11 +14,15 @@ from bravado_core.unmarshal import unmarshal_schema_object
 from bravado_core.validate import validate_schema_object
 from msgpack import unpackb
 
-from bravado.config import REQUEST_OPTIONS_DEFAULTS
+from bravado.config import RequestConfig
 from bravado.exception import BravadoTimeoutError
+from bravado.exception import HTTPError
 from bravado.exception import HTTPServerError
 from bravado.exception import make_http_exception
 from bravado.response import BravadoResponse
+
+
+log = logging.getLogger(__name__)
 
 
 FALLBACK_EXCEPTIONS = (
@@ -91,26 +96,20 @@ class HttpFuture(object):
         response in a non-http client specific way.
     :type response_adapter: type that is a subclass of
         :class:`bravado_core.response.IncomingResponse`.
-    :param response_callbacks: See bravado.client.REQUEST_OPTIONS_DEFAULTS
-    :param also_return_response: Determines if the incoming http response is
-        included as part of the return value from calling
-        `HttpFuture.result()`.
-        When False, only the swagger result is returned.
-        When True, the tuple(swagger result, http response) is returned.
-        This is useful if you want access to additional data that is not
-        accessible from the swagger result. e.g. http headers,
-        http response code, etc.
-        Defaults to False for backwards compatibility.
+    :param RequestConfig request_config: See :class:`bravado.config.RequestConfig` and
+        :data:`bravado.client.REQUEST_OPTIONS_DEFAULTS`
     """
 
     def __init__(self, future, response_adapter, operation=None,
-                 response_callbacks=None, also_return_response=False):
+                 request_config=None):
         self._start_time = monotonic.monotonic()
         self.future = future
         self.response_adapter = response_adapter
         self.operation = operation
-        self.response_callbacks = response_callbacks or REQUEST_OPTIONS_DEFAULTS['response_callbacks']
-        self.also_return_response = also_return_response
+        self.request_config = request_config or RequestConfig.from_request_options_dict(
+            {},
+            also_return_response_default=False,
+        )
 
     def response(self, timeout=None, fallback_result=None, exceptions_to_catch=FALLBACK_EXCEPTIONS):
         """Blocking call to wait for the HTTP response.
@@ -136,9 +135,25 @@ class HttpFuture(object):
         try:
             incoming_response = self._get_incoming_response(timeout)
             request_end_time = monotonic.monotonic()
+
+            # Trigger fallback_result if the option is set
+            if fallback_result and self.request_config.force_fallback_result:
+                if self.operation.swagger_spec.config['bravado'].disable_fallback_results:
+                    log.warning(
+                        'force_fallback_result set in request options and disable_fallback_results '
+                        'set in client config; not using fallback result.'
+                    )
+                else:
+                    # raise an exception to trigger fallback result handling
+                    fake_exception_type = exceptions_to_catch[0]
+                    args = (incoming_response,) if issubclass(fake_exception_type, HTTPError) else ()
+                    raise fake_exception_type(*args)
+
             swagger_result = self._get_swagger_result(incoming_response)
+
             if self.operation is None and incoming_response.status_code >= 300:
                 raise make_http_exception(response=incoming_response)
+
         except exceptions_to_catch as e:
             if request_end_time is None:
                 request_end_time = monotonic.monotonic()
@@ -162,6 +177,7 @@ class HttpFuture(object):
             start_time=self._start_time,
             request_end_time=request_end_time,
             handled_exception_info=exc_info,
+            request_config=self.request_config,
         )
         return BravadoResponse(
             result=swagger_result,
@@ -183,7 +199,7 @@ class HttpFuture(object):
         swagger_result = self._get_swagger_result(incoming_response)
 
         if self.operation is not None:
-            if self.also_return_response:
+            if self.request_config.also_return_response:
                 return swagger_result, incoming_response
             return swagger_result
 
@@ -204,7 +220,7 @@ class HttpFuture(object):
             unmarshal_response(
                 incoming_response,
                 self.operation,
-                self.response_callbacks,
+                self.request_config.response_callbacks,
             )
             swagger_result = incoming_response.swagger_result
 

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -124,8 +124,7 @@ class RequestsClient(HttpClient):
 
         return sanitized_params, misc_options
 
-    def request(self, request_params, operation=None, response_callbacks=None,
-                also_return_response=False):
+    def request(self, request_params, operation=None, request_config=None):
         """
         :param request_params: complete request data.
         :type request_params: dict
@@ -133,10 +132,7 @@ class RequestsClient(HttpClient):
             to None - in which case, we're obviously just retrieving a Swagger
             Spec.
         :type operation: :class:`bravado_core.operation.Operation`
-        :param response_callbacks: List of callables to post-process the
-            incoming response. Expects args incoming_response and operation.
-        :param also_return_response: Consult the constructor documentation for
-            :class:`bravado.http_future.HttpFuture`.
+        :param RequestConfig request_config: per-request configuration
 
         :returns: HTTP Future object
         :rtype: :class: `bravado_core.http_future.HttpFuture`
@@ -153,8 +149,7 @@ class RequestsClient(HttpClient):
             requests_future,
             RequestsResponseAdapter,
             operation,
-            response_callbacks,
-            also_return_response,
+            request_config,
         )
 
     def set_basic_auth(self, host, username, password):

--- a/bravado/response.py
+++ b/bravado/response.py
@@ -39,7 +39,15 @@ class BravadoResponseMetadata(object):
         representation of the traceback in case an exception was caught during request processing.
     """
 
-    def __init__(self, incoming_response, swagger_result, start_time, request_end_time, handled_exception_info):
+    def __init__(
+        self,
+        incoming_response,
+        swagger_result,
+        start_time,
+        request_end_time,
+        handled_exception_info,
+        request_config,
+    ):
         """
         :param incoming_response: a subclass of bravado_core.response.IncomingResponse.
         :param swagger_result: the unmarshalled result that is being returned to the user.
@@ -51,12 +59,15 @@ class BravadoResponseMetadata(object):
         :param handled_exception_info: sys.exc_info() data if an exception was caught and handled as
             part of a fallback response; note that the third element in the list is a string representation
             of the traceback, not a traceback object.
+        :param RequestConfig request_config: namedtuple containing the request options that were used
+            for making this request.
         """
         self._incoming_response = incoming_response
         self.start_time = start_time
         self.request_end_time = request_end_time
         self.processing_end_time = monotonic.monotonic()
         self.handled_exception_info = handled_exception_info
+        self.request_config = request_config
 
         # we expose the result to the user through the BravadoResponse object;
         # we're passing it in to this object in case custom implementations need it

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -220,6 +220,13 @@ with this case.
 :attr:`.BravadoResponseMetadata.is_fallback_result` will be True if a fallback result has been returned
 by the call to :meth:`.HttpFuture.response`.
 
+Testing fallback results
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can trigger returning fallback results for testing purposes. Just set the option ``force_fallback_result``
+to ``True`` in the request configuration (see :ref:`request_config`). In this case a :class:`.ForcedFallbackResultError`
+exception will be passed to your fallback result callback, so make sure you handle it properly.
+
 .. _custom_response_metadata:
 
 Custom response metadata

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -234,8 +234,16 @@ In your code, create a class that subclasses :class:`bravado.response.BravadoRes
 of your properties, use :attr:`.BravadoResponseMetadata.headers` to access response headers, or
 :attr:`.BravadoResponseMetadata.incoming_response` to access any other part of the HTTP response.
 
-If, for some reason, you need your own ``__init__`` method, make sure you have the same signature
-as the base method and that you call it (the base method) from your own implementation.
+If, for some reason, you need your own ``__init__`` method, make sure that your signature accepts
+any positional and keyword argument, and that you call the base method with these arguments from
+your own implementation. That way, your class will remain compatible with the base class even
+if new arguments get added to the __init__ method. Example minimal implementation:
+
+.. code-block:: python
+
+    class MyResponseMetadata(ResponseMetadata):
+        def __init__(self, *args, **kwargs):
+            super(MyResponseMetadata, self).__init__(*args, **kwargs)
 
 While developing custom :class:`.BravadoResponseMetadata` classes we recommend to avoid,
 if possible, the usage of attributes for data that's expensive to compute. Since the object

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -70,6 +70,8 @@ Config key                 Type            Description
                                            Default: ``False``
 ========================== =============== ===============================================================
 
+.. _request_configuration:
+
 Per-request Configuration
 --------------------------
 Configuration can also be applied on a per-request basis by passing in

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -100,4 +100,7 @@ Config key                Type            Default    Description
                                                      | http_client when making a service call.
 *use_msgpack*             boolean         False      | If a msgpack serialization is desired for the response. This
                                                      | will add a Accept: application/msgpack header to the request.
+*force_fallback_result*   boolean         False      | Whether a potentially provided fallback result should always
+                                                     | be returned, regardless of whether the request succeeded.
+                                                     | Mainly useful for manual and automated testing.
 ========================= =============== =========  ===============================================================

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,6 @@ setup(
     ],
     extras_require={
         "fido": ["fido >= 4.2.1"],
+        ':python_version<"3.5"': ['typing'],
     },
 )

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -5,6 +5,7 @@ import pytest
 from bravado.config import _get_response_metadata_class
 from bravado.config import BravadoConfig
 from bravado.config import CONFIG_DEFAULTS
+from bravado.config import RequestConfig
 from bravado.response import BravadoResponseMetadata
 
 
@@ -60,3 +61,43 @@ def test_get_response_metadata_class_invalid_class(mock_log):
     assert metadata_class is BravadoResponseMetadata
     assert mock_log.warning.call_count == 1
     assert 'does not extend' in mock_log.warning.call_args[0][0]
+
+
+def test_empty_request_config():
+    request_config = RequestConfig({}, also_return_response_default=False)
+    _assert_request_config_equals(
+        request_config,
+        also_return_response=False,
+        force_fallback_result=False,
+        response_callbacks=[],
+        connect_timeout=None,
+        headers={},
+        use_msgpack=False,
+        timeout=None,
+        additional_properties={},
+    )
+
+
+def test_request_config_all_values():
+    request_options = {
+        'also_return_response': True,
+        'force_fallback_result': True,
+        'response_callbacks': [lambda ir, op: None],
+        'connect_timeout': 0.2,
+        'headers': {'X-Speed-Up': '1'},
+        'use_msgpack': True,
+        'timeout': 2,
+        'http_client_option': 'a value',
+    }
+
+    request_config = RequestConfig(request_options, also_return_response_default=False)
+    request_options['additional_properties'] = {
+        'http_client_option': request_options.pop('http_client_option')
+    }
+    _assert_request_config_equals(request_config, **request_options)
+
+
+def _assert_request_config_equals(request_config, **kwargs):
+    for name, value in kwargs.items():
+        assert hasattr(request_config, name)
+        assert getattr(request_config, name) == value

--- a/tests/http_future/HttpFuture/response_test.py
+++ b/tests/http_future/HttpFuture/response_test.py
@@ -4,7 +4,9 @@ import pytest
 from bravado_core.response import IncomingResponse
 
 from bravado.config import BravadoConfig
+from bravado.config import RequestConfig
 from bravado.exception import BravadoTimeoutError
+from bravado.exception import HTTPInternalServerError
 from bravado.http_future import HttpFuture
 from bravado.response import BravadoResponseMetadata
 
@@ -14,14 +16,18 @@ class ResponseMetadata(BravadoResponseMetadata):
 
 
 @pytest.fixture
+def mock_incoming_response():
+    return mock.Mock(spec=IncomingResponse, status_code=200, swagger_result=mock.Mock(name='swagger_result'))
+
+
+@pytest.fixture
 def mock_operation():
     return mock.Mock(name='operation')
 
 
 @pytest.fixture
-def http_future(mock_future_adapter, mock_operation):
-    response_adapter_instance = mock.Mock(spec=IncomingResponse, status_code=200, swagger_result=None)
-    response_adapter_type = mock.Mock(return_value=response_adapter_instance)
+def http_future(mock_future_adapter, mock_operation, mock_incoming_response):
+    response_adapter_type = mock.Mock(return_value=mock_incoming_response)
     return HttpFuture(
         future=mock_future_adapter,
         response_adapter=response_adapter_type,
@@ -29,8 +35,12 @@ def http_future(mock_future_adapter, mock_operation):
     )
 
 
-def test_fallback_result(mock_future_adapter, mock_operation, http_future):
-    fallback_result = mock.Mock(name='fallback result')
+@pytest.fixture
+def fallback_result():
+    return mock.Mock(name='fallback result')
+
+
+def test_fallback_result(fallback_result, mock_future_adapter, mock_operation, http_future):
     mock_future_adapter.result.side_effect = BravadoTimeoutError()
     mock_operation.swagger_spec.config = {
         'bravado': BravadoConfig.from_config_dict({'disable_fallback_results': False})
@@ -58,6 +68,42 @@ def test_no_fallback_result_if_config_disabled(mock_future_adapter, mock_operati
 
     with pytest.raises(BravadoTimeoutError):
         http_future.response(fallback_result=lambda e: None)
+
+
+def test_force_fallback_result(mock_incoming_response, mock_operation, fallback_result, http_future):
+    http_future.request_config = RequestConfig.from_request_options_dict(
+        {'force_fallback_result': True},
+        also_return_response_default=False,
+    )
+    mock_operation.swagger_spec.config = {
+        'bravado': BravadoConfig.from_config_dict({})
+    }
+
+    with mock.patch('bravado.http_future.unmarshal_response', autospec=True):
+        response = http_future.response(
+            fallback_result=lambda e: fallback_result,
+            exceptions_to_catch=(HTTPInternalServerError,),
+        )
+
+    assert response.result == fallback_result
+    assert response.metadata.is_fallback_result is True
+    assert response.metadata.handled_exception_info[0] is HTTPInternalServerError
+    assert response.metadata.handled_exception_info[1].response is mock_incoming_response
+
+
+def test_no_force_fallback_result_if_disabled(http_future, mock_operation, mock_incoming_response, fallback_result):
+    http_future.request_config = RequestConfig.from_request_options_dict(
+        {'force_fallback_result': True},
+        also_return_response_default=False,
+    )
+    mock_operation.swagger_spec.config = {
+        'bravado': BravadoConfig.from_config_dict({'disable_fallback_results': True})
+    }
+
+    with mock.patch('bravado.http_future.unmarshal_response', autospec=True):
+        response = http_future.response(fallback_result=lambda e: fallback_result)
+
+    assert response.result == mock_incoming_response.swagger_result
 
 
 def test_custom_response_metadata(mock_operation, http_future):

--- a/tests/http_future/HttpFuture/result_test.py
+++ b/tests/http_future/HttpFuture/result_test.py
@@ -82,7 +82,7 @@ def test_also_return_response_true(_, mock_future_adapter):
         future=mock_future_adapter,
         response_adapter=response_adapter_type,
         operation=Mock(spec=Operation),
-        request_config=RequestConfig.from_request_options_dict({}, also_return_response_default=True))
+        request_config=RequestConfig({}, also_return_response_default=True))
 
     swagger_result, http_response = http_future.result()
 

--- a/tests/http_future/HttpFuture/result_test.py
+++ b/tests/http_future/HttpFuture/result_test.py
@@ -5,6 +5,7 @@ from bravado_core.response import IncomingResponse
 from mock import Mock
 from mock import patch
 
+from bravado.config import RequestConfig
 from bravado.exception import HTTPError
 from bravado.http_future import HttpFuture
 
@@ -81,7 +82,7 @@ def test_also_return_response_true(_, mock_future_adapter):
         future=mock_future_adapter,
         response_adapter=response_adapter_type,
         operation=Mock(spec=Operation),
-        also_return_response=True)
+        request_config=RequestConfig.from_request_options_dict({}, also_return_response_default=True))
 
     swagger_result, http_response = http_future.result()
 

--- a/tests/response_test.py
+++ b/tests/response_test.py
@@ -12,6 +12,7 @@ def test_response_metadata_times():
             start_time=5,
             request_end_time=10,
             handled_exception_info=None,
+            request_config=None,
         )
 
     assert metadata.elapsed_time == 6


### PR DESCRIPTION
First iteration at supporting forcing fallback results. Since that would require a backwards-incompatible change, I went and tried to rework it in a way that would make it possible to do these things without breaking compatibility in the future.