### PR TITLE
Support per-request API key header overwrite by _request_options

### DIFF
--- a/CHANGELOG-MASTER.rst
+++ b/CHANGELOG-MASTER.rst
@@ -4,3 +4,5 @@ Changelog-Master
 *This file will contain the Changelog of the master branch.*
 
 *The content will be used to build the Changelog of the new bravado release.*
+
+Support per-request API key header overwrite by `_request_options`

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -67,7 +67,7 @@ class ApiKeyAuthenticator(Authenticator):
 
     def apply(self, request):
         if self.param_in == 'header':
-            request.headers[self.param_name] = self.api_key
+            request.headers.setdefault(self.param_name, self.api_key)
         else:
             request.params[self.param_name] = self.api_key
         return request

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -135,6 +135,27 @@ class RequestsClientTestCase(unittest.TestCase):
         self.assertEqual('abc123', httpretty.last_request().headers['Key'])
 
     @httpretty.activate
+    def test_api_key_header_overwrite(self):
+        httpretty.register_uri(
+            httpretty.GET, "http://swagger.py/client-test",
+            body='expected')
+
+        client = RequestsClient()
+        client.set_api_key("swagger.py", 'abc123', param_name='Key',
+                           param_in='header')
+        params = self._default_params()
+        params['params'] = {'foo': 'bar'}
+        params['headers'] = {'Key': 'def456'}
+
+        resp = client.request(params).result()
+
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual('expected', resp.text)
+        self.assertEqual({'foo': ['bar']},
+                         httpretty.last_request().querystring)
+        self.assertEqual('def456', httpretty.last_request().headers['Key'])
+
+    @httpretty.activate
     def test_auth_leak(self):
         httpretty.register_uri(
             httpretty.GET, "http://hackerz.py",


### PR DESCRIPTION
Fixes problem from #373 . Probably there might be some more uses cases (not only a header).