### PR TITLE
Introduce testing mocks for responses

### DIFF
--- a/bravado/testing/response_mocks.py
+++ b/bravado/testing/response_mocks.py
@@ -1,9 +1,17 @@
 # -*- coding: utf-8 -*-
-import mock
+from bravado_core.response import IncomingResponse
 
 from bravado.exception import BravadoTimeoutError
 from bravado.http_future import FALLBACK_EXCEPTIONS
 from bravado.response import BravadoResponseMetadata
+
+
+class FakeIncomingResponse(IncomingResponse):
+    def __init__(self, status_code, **kwargs):
+        self.headers = {}
+        self.status_code = status_code
+        for name, value in kwargs.items():
+            setattr(self, name, value)
 
 
 class BravadoResponseMock(object):
@@ -17,10 +25,7 @@ class BravadoResponseMock(object):
             self._metadata = metadata
         else:
             self._metadata = BravadoResponseMetadata(
-                incoming_response=mock.Mock(
-                    status_code=200,
-                    headers={},
-                ),
+                incoming_response=FakeIncomingResponse(status_code=200),
                 swagger_result=self._result,
                 start_time=1528733800,
                 request_end_time=1528733801,
@@ -61,6 +66,8 @@ class FallbackResultBravadoResponseMock(object):
             )
 
     def __call__(self, timeout=None, fallback_result=None, exceptions_to_catch=FALLBACK_EXCEPTIONS):
+        assert callable(fallback_result), 'You\'re using FallbackResultBravadoResponseMock without a callable ' + \
+            'fallback_result. Either provide a callable or use BravadoResponseMock.'
         self._fallback_result = fallback_result(self._exception)
         self._metadata._swagger_result = self._fallback_result
         return self

--- a/bravado/testing/response_mocks.py
+++ b/bravado/testing/response_mocks.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from bravado.exception import BravadoTimeoutError
+from bravado.http_future import FALLBACK_EXCEPTIONS
+from bravado.response import BravadoResponseMetadata
+
+
+class BravadoResponseMock(object):
+    def __init__(self, result):
+        self._result = result
+
+    def __call__(self, timeout=None, fallback_result=None, exceptions_to_catch=FALLBACK_EXCEPTIONS):
+        return self
+
+    @property
+    def result(self):
+        return self._result
+
+    @property
+    def metadata(self):
+        return BravadoResponseMetadata(
+            incoming_response='incoming response',
+            swagger_result=self._result,
+            start_time=1528733800,
+            request_end_time=1528733801,
+            handled_exception_info=None,
+            request_config=None,
+        )
+
+
+class DegradedBravadoResponseMock(object):
+    def __init__(self, exception=BravadoTimeoutError()):
+        self._exception = exception
+
+    def __call__(self, timeout=None, fallback_result=None, exceptions_to_catch=FALLBACK_EXCEPTIONS):
+        self._fallback_result = fallback_result(self._exception)
+        return self
+
+    @property
+    def result(self):
+        return self._fallback_result
+
+    @property
+    def metadata(self):
+        return BravadoResponseMetadata(
+            incoming_response=None,
+            swagger_result=self._fallback_result,
+            start_time=1528733800,
+            request_end_time=1528733801,
+            handled_exception_info=(self._exception.__class__, self._exception, 'Traceback'),
+            request_config=None,
+        )
+
+
+def make_bravado_response(result, degraded=False):
+    if degraded:
+        return DegradedBravadoResponseMock()
+    else:
+        return BravadoResponseMock(result)

--- a/bravado/testing/response_mocks.py
+++ b/bravado/testing/response_mocks.py
@@ -6,7 +6,7 @@ from bravado.http_future import FALLBACK_EXCEPTIONS
 from bravado.response import BravadoResponseMetadata
 
 
-class FakeIncomingResponse(IncomingResponse):
+class IncomingResponseMock(IncomingResponse):
     def __init__(self, status_code, **kwargs):
         self.headers = {}
         self.status_code = status_code
@@ -25,7 +25,7 @@ class BravadoResponseMock(object):
             self._metadata = metadata
         else:
             self._metadata = BravadoResponseMetadata(
-                incoming_response=FakeIncomingResponse(status_code=200),
+                incoming_response=IncomingResponseMock(status_code=200),
                 swagger_result=self._result,
                 start_time=1528733800,
                 request_end_time=1528733801,

--- a/bravado/testing/response_mocks.py
+++ b/bravado/testing/response_mocks.py
@@ -1,12 +1,32 @@
 # -*- coding: utf-8 -*-
+import mock
+
 from bravado.exception import BravadoTimeoutError
 from bravado.http_future import FALLBACK_EXCEPTIONS
 from bravado.response import BravadoResponseMetadata
 
 
 class BravadoResponseMock(object):
-    def __init__(self, result):
+    """Class that behaves like the :meth:`.HttpFuture.response` method as well as a :class:`.BravadoResponse`.
+    Please check the documentation for further information.
+    """
+
+    def __init__(self, result, metadata=None):
         self._result = result
+        if metadata:
+            self._metadata = metadata
+        else:
+            self._metadata = BravadoResponseMetadata(
+                incoming_response=mock.Mock(
+                    status_code=200,
+                    headers={},
+                ),
+                swagger_result=self._result,
+                start_time=1528733800,
+                request_end_time=1528733801,
+                handled_exception_info=None,
+                request_config=None,
+            )
 
     def __call__(self, timeout=None, fallback_result=None, exceptions_to_catch=FALLBACK_EXCEPTIONS):
         return self
@@ -17,22 +37,32 @@ class BravadoResponseMock(object):
 
     @property
     def metadata(self):
-        return BravadoResponseMetadata(
-            incoming_response='incoming response',
-            swagger_result=self._result,
-            start_time=1528733800,
-            request_end_time=1528733801,
-            handled_exception_info=None,
-            request_config=None,
-        )
+        return self._metadata
 
 
-class DegradedBravadoResponseMock(object):
-    def __init__(self, exception=BravadoTimeoutError()):
+class FallbackResultBravadoResponseMock(object):
+    """Class that behaves like the :meth:`.HttpFuture.response` method as well as a :class:`.BravadoResponse`.
+    It will always call the ``fallback_result`` callback that's passed to the ``response()`` method.
+    Please check the documentation for further information.
+    """
+
+    def __init__(self, exception=BravadoTimeoutError(), metadata=None):
         self._exception = exception
+        if metadata:
+            self._metadata = metadata
+        else:
+            self._metadata = BravadoResponseMetadata(
+                incoming_response=None,
+                swagger_result=None,  # we're going to set it later
+                start_time=1528733800,
+                request_end_time=1528733801,
+                handled_exception_info=(self._exception.__class__, self._exception, 'Traceback'),
+                request_config=None,
+            )
 
     def __call__(self, timeout=None, fallback_result=None, exceptions_to_catch=FALLBACK_EXCEPTIONS):
         self._fallback_result = fallback_result(self._exception)
+        self._metadata._swagger_result = self._fallback_result
         return self
 
     @property
@@ -41,18 +71,4 @@ class DegradedBravadoResponseMock(object):
 
     @property
     def metadata(self):
-        return BravadoResponseMetadata(
-            incoming_response=None,
-            swagger_result=self._fallback_result,
-            start_time=1528733800,
-            request_end_time=1528733801,
-            handled_exception_info=(self._exception.__class__, self._exception, 'Traceback'),
-            request_config=None,
-        )
-
-
-def make_bravado_response(result, degraded=False):
-    if degraded:
-        return DegradedBravadoResponseMock()
-    else:
-        return BravadoResponseMock(result)
+        return self._metadata

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -139,7 +139,7 @@ The default behavior for a service call is to return the swagger result like so:
 
 .. code-block:: python
 
-    pet = petstore.pet.getPetById(petId=42).response().result
+    pet = client.pet.getPetById(petId=42).response().result
     print pet.name
 
 However, there are times when it is necessary to have access to the actual
@@ -149,7 +149,7 @@ attribute to access the incoming response:
 
 .. code-block:: python
 
-    petstore = Swagger.from_url(
+    petstore = SwaggerClient.from_url(
         'http://petstore.swagger.io/swagger.json',
         config={'also_return_response': True},
     )
@@ -179,7 +179,7 @@ In the simplest case, you can just specify what you're going to return:
 
 .. code-block:: python
 
-    petstore = Swagger.from_url('http://petstore.swagger.io/swagger.json')
+    petstore = SwaggerClient.from_url('http://petstore.swagger.io/swagger.json')
     response = petstore.pet.findPetsByStatus(status=['available']).response(
         timeout=0.5,
         fallback_result=lambda e: [],
@@ -206,7 +206,7 @@ to return one as well from your fallback_result function to stay compatible with
 
 .. code-block:: python
 
-    petstore = Swagger.from_url('http://petstore.swagger.io/swagger.json')
+    petstore = SwaggerClient.from_url('http://petstore.swagger.io/swagger.json')
     response = petstore.pet.getPetById(petId=101).response(
         timeout=0.5,
         fallback_result=lambda e: petstore.get_model('Pet')(name='No Pet found', photoUrls=[]),
@@ -224,7 +224,7 @@ Testing fallback results
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can trigger returning fallback results for testing purposes. Just set the option ``force_fallback_result``
-to ``True`` in the request configuration (see :ref:`request_config`). In this case a :class:`.ForcedFallbackResultError`
+to ``True`` in the request configuration (see :ref:`request_configuration`). In this case a :class:`.ForcedFallbackResultError`
 exception will be passed to your fallback result callback, so make sure you handle it properly.
 
 .. _custom_response_metadata:

--- a/docs/source/bravado.rst
+++ b/docs/source/bravado.rst
@@ -63,3 +63,11 @@ bravado Package
     :members:
     :undoc-members:
     :show-inheritance:
+
+:mod:`testing` Module
+-----------------------
+
+.. automodule:: bravado.testing.response_mocks
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,5 +39,6 @@ htmlhelp_basename = 'bravado-pydoc'
 
 
 intersphinx_mapping = {
-    'http://docs.python.org/': None
+    'python': ('http://docs.python.org/', None),
+    'bravado-core': ('https://bravado-core.readthedocs.io/en/latest/', None),
 }

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -55,10 +55,12 @@ Config key                 Type            Description
 -------------------------- --------------- ---------------------------------------------------------------
 *response_metadata_class*  string          | The Metadata class to use; see
                                            | :ref:`custom_response_metadata` for details.
+
                                            Default: :class:`bravado.response.BravadoResponseMetadata`
 *disable_fallback_results* boolean         | Whether to disable returning fallback results, even if
                                            | they're provided as an argument to
                                            | to :meth:`.HttpFuture.response`.
+
                                            Default: ``False``
 *also_return_response*     boolean         | Determines what is returned by the service call.
                                            | Specifically, the return value of :meth:`.HttpFuture.result`.
@@ -67,6 +69,7 @@ Config key                 Type            Description
                                            | is returned. Has no effect on the return value of
                                            | :meth:`.HttpFuture.response`.
                                            | See :ref:`getting_access_to_the_http_response`.
+
                                            Default: ``False``
 ========================== =============== ===============================================================
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,6 +33,7 @@ Contents:
    configuration
    requests_and_responses
    advanced
+   testing
    modules
    changelog
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -93,7 +93,7 @@ This is too fancy for me! I want a simple dict response!
 
 ``result`` will look something like:
 
-.. code-block:: json
+.. code-block:: javascript
 
         {
             'category': {

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -1,0 +1,114 @@
+.. py:currentmodule:: bravado.testing.response_mocks
+
+Testing code that uses bravado
+==============================
+
+Writing tests is crucial in making sure your code works and behaves as expected. bravado ships with two classes
+that will help you create robust unit tests to verify the correctness of your code. We'll be using the excellent
+`pytest <https://pytest.org/>`_ library in this example.
+
+First of all, let's define the code we'd like to test:
+
+.. code-block:: python
+
+    from itertools import chain
+
+    from bravado.client import SwaggerClient
+
+    def get_available_pet_photos():
+        petstore = SwaggerClient.from_url(
+            'http://petstore.swagger.io/swagger.json',
+        )
+        pets = petstore.pet.findPetsByStatus(status=['available']).response(
+            timeout=0.5,
+            fallback_result=lambda e: [],
+        ).result
+
+        return chain.from_iterable(pet.photoUrls for pet in pets)
+
+First of all, in order to make sure your code doesn't do any network requests, you need to mock out the bravado client:
+
+.. code-block:: python
+
+    import mock
+    import pytest
+
+    from bravado.client import SwaggerClient
+
+    @pytest.fixture
+    def mock_client():
+        mock_client = mock.Mock(name='mock SwaggerClient')
+        with mock.patch.object(SwaggerClient, 'from_url', return_value=mock_client):
+            yield mock_client
+
+Now we can mock out that call to ``findPetsByStatus`` by using the
+:class:`bravado.testing.response_mocks.BravadoResponseMock` class:
+
+.. code-block:: python
+
+    import mock
+
+    from bravado.testing.response_mocks import BravadoResponseMock
+
+    from mypackage import get_available_pet_photos
+
+    def test_get_available_pet_photos(mock_client):
+        mock_pets = [
+            mock.Mock(
+                photoUrls=['https://example.com/image.png'],
+            ),
+            mock.Mock(
+                photoUrls=[
+                    'https://example.com/image2.png',
+                    'https://example.com/image3.png',
+                ],
+            ),
+        ]
+
+        mock_client.pet.findPetsByStatus.return_value.response = BravadoResponseMock(
+            result=mock_pets,
+        )
+
+        pet_photos = get_available_pet_photos()
+
+        assert list(pet_photos) == [
+            'https://example.com/image.png',
+            'https://example.com/image2.png',
+            'https://example.com/image3.png',
+        ]
+
+Note that it's your responsibility to ensure that what you set as result for :class:`BravadoResponseMock` is
+sufficiently similar to what bravado would return in production. We've used a ``Mock`` class here; another option
+is to define namedtuples that correspond to your Swagger spec objects. This gives you even greater confidence
+in the correctness of your code since access to undefined fields will result in an error.
+
+Testing degraded responses
+--------------------------
+
+Use :class:`FallbackResultBravadoResponseMock` to test :ref:`fallback results <fallback_results>`. It works similarly,
+but you don't have to pass the result to the constructor, since your fallback result callback will determine the result.
+Let's add another test to verify our fallback result code path works properly:
+
+.. code-block:: python
+
+    from bravado.testing.response_mocks import FallbackResultBravadoResponseMock
+
+    from example import get_available_pet_photos
+
+    def test_get_available_pet_photos_fallback_result(mock_client):
+        mock_client.pet.findPetsByStatus.return_value\
+            .response = FallbackResultBravadoResponseMock()
+
+        pet_photos = get_available_pet_photos()
+
+        assert list(pet_photos) == []
+
+Note that you can pass in a custom exception instance to :class:`.FallbackResultBravadoResponseMock` if you need
+to trigger specific exception handling in your fallback result callback.
+
+Setting custom response metadata
+--------------------------------
+
+Both :class:`.BravadoResponseMock` as well as :class:`.FallbackResultBravadoResponseMock` accept an optional
+``metadata`` argument. Just pass in an instance of :class:`.BravadoResponseMetadata` that you'd like to be used.
+A default one will be provided otherwise.

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
     ],
     extras_require={
         'fido': ['fido >= 4.2.1'],
-        'testing': ['mock'],
         ':python_version<"3.5"': ['typing'],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -4,43 +4,45 @@
 # Copyright (c) 2014-2016, Yelp, Inc.
 import os
 
+from setuptools import find_packages
 from setuptools import setup
 
 import bravado
 
 setup(
-    name="bravado",
+    name='bravado',
     version=bravado.version,
-    license="BSD 3-Clause License",
-    description="Library for accessing Swagger-enabled API's",
+    license='BSD 3-Clause License',
+    description='Library for accessing Swagger-enabled API\'s',
     long_description=open(os.path.join(os.path.dirname(__file__),
-                                       "README.rst")).read(),
-    author="Digium, Inc. and Yelp, Inc.",
-    author_email="opensource+bravado@yelp.com",
-    url="https://github.com/Yelp/bravado",
-    packages=["bravado"],
+                                       'README.rst')).read(),
+    author='Digium, Inc. and Yelp, Inc.',
+    author_email='opensource+bravado@yelp.com',
+    url='https://github.com/Yelp/bravado',
+    packages=find_packages(include=['bravado*']),
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "License :: OSI Approved :: BSD License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     install_requires=[
-        "bravado-core >= 5.0.1",
-        "msgpack-python",
-        "python-dateutil",
-        "pyyaml",
-        "requests >= 2.4",
-        "six",
-        "monotonic",
+        'bravado-core >= 5.0.1',
+        'msgpack-python',
+        'python-dateutil',
+        'pyyaml',
+        'requests >= 2.4',
+        'six',
+        'monotonic',
     ],
     extras_require={
-        "fido": ["fido >= 4.2.1"],
+        'fido': ['fido >= 4.2.1'],
+        'testing': ['mock'],
         ':python_version<"3.5"': ['typing'],
     },
 )

--- a/tests/testing/response_mocks_test.py
+++ b/tests/testing/response_mocks_test.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+import inspect
+
+import mock
+import pytest
+
+from bravado.exception import HTTPServerError
+from bravado.http_future import HttpFuture
+from bravado.response import BravadoResponseMetadata
+from bravado.testing.response_mocks import BravadoResponseMock
+from bravado.testing.response_mocks import DegradedBravadoResponseMock
+from bravado.testing.response_mocks import make_bravado_response
+
+
+@pytest.fixture
+def mock_result():
+    return mock.Mock(name='mock result')
+
+
+def test_response_mock_signatures():
+    """Make sure the mocks' __call__ methods have the same signature as HttpFuture.response"""
+    response_signature = inspect.getargspec(HttpFuture.response)
+
+    assert inspect.getargspec(BravadoResponseMock.__call__) == response_signature
+    assert inspect.getargspec(DegradedBravadoResponseMock.__call__) == response_signature
+
+
+@pytest.mark.parametrize(
+    'is_degraded, expected_class',
+    (
+        (False, BravadoResponseMock),
+        (True, DegradedBravadoResponseMock)
+    )
+)
+def test_make_bravado_response(is_degraded, expected_class, mock_result):
+    response = make_bravado_response(mock_result, degraded=is_degraded)
+
+    assert isinstance(response, expected_class)
+
+
+def test_bravado_response(mock_result):
+    response_mock = BravadoResponseMock(mock_result)
+    response = response_mock()
+
+    assert response.result is mock_result
+    assert isinstance(response.metadata, BravadoResponseMetadata)
+    assert response.metadata._swagger_result is mock_result
+
+
+def test_degraded_bravado_response(mock_result):
+    exception = HTTPServerError(mock.Mock('incoming response', status_code=500))
+
+    def handle_fallback_result(exc):
+        assert exc is exception
+        return mock_result
+
+    response_mock = DegradedBravadoResponseMock(exception)
+    response = response_mock(fallback_result=handle_fallback_result)
+
+    assert response.result is mock_result
+    assert isinstance(response.metadata, BravadoResponseMetadata)
+    assert response.metadata._swagger_result is mock_result

--- a/tests/testing/response_mocks_test.py
+++ b/tests/testing/response_mocks_test.py
@@ -8,8 +8,7 @@ from bravado.exception import HTTPServerError
 from bravado.http_future import HttpFuture
 from bravado.response import BravadoResponseMetadata
 from bravado.testing.response_mocks import BravadoResponseMock
-from bravado.testing.response_mocks import DegradedBravadoResponseMock
-from bravado.testing.response_mocks import make_bravado_response
+from bravado.testing.response_mocks import FallbackResultBravadoResponseMock
 
 
 @pytest.fixture
@@ -17,25 +16,24 @@ def mock_result():
     return mock.Mock(name='mock result')
 
 
+@pytest.fixture
+def mock_metadata():
+    return BravadoResponseMetadata(
+        incoming_response=None,
+        swagger_result=None,
+        start_time=5,
+        request_end_time=6,
+        handled_exception_info=None,
+        request_config=None,
+    )
+
+
 def test_response_mock_signatures():
     """Make sure the mocks' __call__ methods have the same signature as HttpFuture.response"""
     response_signature = inspect.getargspec(HttpFuture.response)
 
     assert inspect.getargspec(BravadoResponseMock.__call__) == response_signature
-    assert inspect.getargspec(DegradedBravadoResponseMock.__call__) == response_signature
-
-
-@pytest.mark.parametrize(
-    'is_degraded, expected_class',
-    (
-        (False, BravadoResponseMock),
-        (True, DegradedBravadoResponseMock)
-    )
-)
-def test_make_bravado_response(is_degraded, expected_class, mock_result):
-    response = make_bravado_response(mock_result, degraded=is_degraded)
-
-    assert isinstance(response, expected_class)
+    assert inspect.getargspec(FallbackResultBravadoResponseMock.__call__) == response_signature
 
 
 def test_bravado_response(mock_result):
@@ -47,16 +45,37 @@ def test_bravado_response(mock_result):
     assert response.metadata._swagger_result is mock_result
 
 
-def test_degraded_bravado_response(mock_result):
+def test_bravado_response_custom_metadata(mock_result, mock_metadata):
+    response_mock = BravadoResponseMock(mock_result, metadata=mock_metadata)
+    response = response_mock()
+
+    assert response.metadata is mock_metadata
+
+
+def test_fallback_result_bravado_response(mock_result):
     exception = HTTPServerError(mock.Mock('incoming response', status_code=500))
 
     def handle_fallback_result(exc):
         assert exc is exception
         return mock_result
 
-    response_mock = DegradedBravadoResponseMock(exception)
+    response_mock = FallbackResultBravadoResponseMock(exception)
     response = response_mock(fallback_result=handle_fallback_result)
 
     assert response.result is mock_result
     assert isinstance(response.metadata, BravadoResponseMetadata)
+    assert response.metadata._swagger_result is mock_result
+
+
+def test_fallback_result_bravado_response_custom_metadata(mock_result, mock_metadata):
+    exception = HTTPServerError(mock.Mock('incoming response', status_code=500))
+
+    def handle_fallback_result(exc):
+        assert exc is exception
+        return mock_result
+
+    response_mock = FallbackResultBravadoResponseMock(exception, metadata=mock_metadata)
+    response = response_mock(fallback_result=handle_fallback_result)
+
+    assert response.metadata is mock_metadata
     assert response.metadata._swagger_result is mock_result

--- a/tests/testing/response_mocks_test.py
+++ b/tests/testing/response_mocks_test.py
@@ -79,3 +79,9 @@ def test_fallback_result_bravado_response_custom_metadata(mock_result, mock_meta
 
     assert response.metadata is mock_metadata
     assert response.metadata._swagger_result is mock_result
+
+
+def test_fallback_result_without_callable():
+    response_mock = FallbackResultBravadoResponseMock()
+    with pytest.raises(AssertionError):
+        response_mock(fallback_result={})

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,6 @@ deps =
     sphinx
     sphinx-rtd-theme
     .[fido]
-    .[testing]
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ deps =
     sphinx
     sphinx-rtd-theme
     .[fido]
+    .[testing]
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html
 


### PR DESCRIPTION
Two notable changes from our internal implementation:

1. The \_\_call__ signatures are different. Internally we have `fallback_result` as the first argument (and no `exceptions_to_catch`). I've added a test to make sure these stay in sync with the signature of HttpFuture.response.
2. People are now expected to pass in an exception instance to DegradedBravadoResponseMock. This is necessary so they can test HTTPServerErrors, HTTP client errors and so forth, as these exceptions might require arguments to be provided for instantiation.
3. `metadata._swagger_result` was not set correctly in the degraded response case; this is fixed and tested.