### PR TITLE
Support non-callable fallback results, stabilize API

### DIFF
--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -123,8 +123,7 @@ class HttpFuture(object):
         :type timeout: float
         :param fallback_result: either the swagger result or a callable that accepts an exception as argument
             and returns the swagger result to use in case of errors
-        :type fallback_result: either any type of object that represents a valid Swagger result or a callable that
-            takes an exception and returns a fallback swagger result
+        :type fallback_result: Optional[Union[Any, Callable[[Exception], Any]]]
         :param exceptions_to_catch: Exception classes to catch and call `fallback_result`
             with. Has no effect if `fallback_result` is not provided. By default, `fallback_result`
             will be called for read timeout and server errors (HTTP 5XX).

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -32,6 +32,9 @@ FALLBACK_EXCEPTIONS = (
 )
 
 
+SENTINEL = object()
+
+
 class FutureAdapter(object):
     """
     Mimics a :class:`concurrent.futures.Future` regardless of which client is
@@ -112,23 +115,21 @@ class HttpFuture(object):
             also_return_response_default=False,
         )
 
-    def response(self, timeout=None, fallback_result=None, exceptions_to_catch=FALLBACK_EXCEPTIONS):
+    def response(self, timeout=None, fallback_result=SENTINEL, exceptions_to_catch=FALLBACK_EXCEPTIONS):
         """Blocking call to wait for the HTTP response.
 
         :param timeout: Number of seconds to wait for a response. Defaults to
             None which means wait indefinitely.
         :type timeout: float
-        :param fallback_result: callable that accepts an exception as argument and returns the
-            swagger result to use in case of errors
-        :type fallback_result: callable that takes an exception and returns a fallback swagger result
+        :param fallback_result: either the swagger result or a callable that accepts an exception as argument
+            and returns the swagger result to use in case of errors
+        :type fallback_result: either any type of object that represents a valid Swagger result or a callable that
+            takes an exception and returns a fallback swagger result
         :param exceptions_to_catch: Exception classes to catch and call `fallback_result`
             with. Has no effect if `fallback_result` is not provided. By default, `fallback_result`
             will be called for read timeout and server errors (HTTP 5XX).
         :type exceptions_to_catch: List/Tuple of Exception classes.
         :return: A BravadoResponse instance containing the swagger result and response metadata.
-
-        WARNING: This interface is considered UNSTABLE. Backwards-incompatible API changes may occur;
-        use at your own risk.
         """
         incoming_response = None
         exc_info = None
@@ -146,7 +147,7 @@ class HttpFuture(object):
                 raise make_http_exception(response=incoming_response)
 
             # Trigger fallback_result if the option is set
-            if fallback_result and self.request_config.force_fallback_result:
+            if fallback_result is not SENTINEL and self.request_config.force_fallback_result:
                 if self.operation.swagger_spec.config['bravado'].disable_fallback_results:
                     log.warning(
                         'force_fallback_result set in request options and disable_fallback_results '
@@ -165,10 +166,11 @@ class HttpFuture(object):
             exc_info = list(sys.exc_info()[:2])
             exc_info.append(traceback.format_exc())
             if (
-                fallback_result and self.operation
+                fallback_result is not SENTINEL
+                and self.operation
                 and not self.operation.swagger_spec.config['bravado'].disable_fallback_results
             ):
-                swagger_result = fallback_result(e)
+                swagger_result = fallback_result(e) if callable(fallback_result) else fallback_result
             else:
                 six.reraise(*sys.exc_info())
 

--- a/bravado/response.py
+++ b/bravado/response.py
@@ -5,9 +5,6 @@ import monotonic
 class BravadoResponse(object):
     """Bravado response object containing the swagger result as well as response metadata.
 
-    WARNING: This interface is considered UNSTABLE. Backwards-incompatible API changes may occur;
-    use at your own risk.
-
     :ivar result: Swagger result from the server
     :ivar BravadoResponseMetadata metadata: metadata for this response including HTTP response
     """
@@ -28,9 +25,6 @@ class BravadoResponseMetadata(object):
     the operation object, as we only start measuring once the call to `HTTPClient.request` returns.
     Nevertheless, it should be accurate enough for logging and debugging, i.e. determining what went
     on and how much time was spent waiting for the response.
-
-    WARNING: This interface is considered UNSTABLE. Backwards-incompatible API changes may occur;
-    use at your own risk.
 
     :ivar float start_time: monotonic timestamp at which the future was created
     :ivar float request_end_time: monotonic timestamp at which we received the HTTP response

--- a/bravado/testing/response_mocks.py
+++ b/bravado/testing/response_mocks.py
@@ -3,6 +3,7 @@ from bravado_core.response import IncomingResponse
 
 from bravado.exception import BravadoTimeoutError
 from bravado.http_future import FALLBACK_EXCEPTIONS
+from bravado.http_future import SENTINEL
 from bravado.response import BravadoResponseMetadata
 
 
@@ -33,7 +34,7 @@ class BravadoResponseMock(object):
                 request_config=None,
             )
 
-    def __call__(self, timeout=None, fallback_result=None, exceptions_to_catch=FALLBACK_EXCEPTIONS):
+    def __call__(self, timeout=None, fallback_result=SENTINEL, exceptions_to_catch=FALLBACK_EXCEPTIONS):
         return self
 
     @property
@@ -65,10 +66,10 @@ class FallbackResultBravadoResponseMock(object):
                 request_config=None,
             )
 
-    def __call__(self, timeout=None, fallback_result=None, exceptions_to_catch=FALLBACK_EXCEPTIONS):
-        assert callable(fallback_result), 'You\'re using FallbackResultBravadoResponseMock without a callable ' + \
+    def __call__(self, timeout=None, fallback_result=SENTINEL, exceptions_to_catch=FALLBACK_EXCEPTIONS):
+        assert fallback_result is not SENTINEL, 'You\'re using FallbackResultBravadoResponseMock without a callable ' \
             'fallback_result. Either provide a callable or use BravadoResponseMock.'
-        self._fallback_result = fallback_result(self._exception)
+        self._fallback_result = fallback_result(self._exception) if callable(fallback_result) else fallback_result
         self._metadata._swagger_result = self._fallback_result
         return self
 

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -169,24 +169,29 @@ By default, if the server returns an error or doesn't respond in time, you have 
 the resulting exception accordingly. A simpler way would be to use the support for fallback results
 provided by :meth:`.HttpFuture.response`.
 
-:meth:`.HttpFuture.response` takes an optional argument ``fallback_result`` which is a callable
-that returns a Swagger result. The callable takes one mandatory argument: the exception that would
-have been raised normally. This allows you to return different results based on the type of error
-(e.g. a :class:`.BravadoTimeoutError`) or, if a server response was received, on any data pertaining
-to that response, like the HTTP status code.
-
-In the simplest case, you can just specify what you're going to return:
+:meth:`.HttpFuture.response` takes an optional argument ``fallback_result`` which is the fallback
+Swagger result to return in case of errors:
 
 .. code-block:: python
 
     petstore = SwaggerClient.from_url('http://petstore.swagger.io/swagger.json')
     response = petstore.pet.findPetsByStatus(status=['available']).response(
         timeout=0.5,
-        fallback_result=lambda e: [],
+        fallback_result=[],
     )
 
 This code will return an empty list in case the server doesn't respond quickly enough (or it
 responded quickly enough, but returned an error).
+
+Handling error types differently
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes, you might want to treat timeout errors differently from server errors. To do this you may
+pass in a callable as ``fallback_result`` argument. The callable takes one mandatory argument: the exception
+that would have been raised normally. This allows you to return different results based on the type of error
+(e.g. a :class:`.BravadoTimeoutError`) or, if a server response was received, on any data pertaining
+to that response, like the HTTP status code. Subclasses of :class:`.HTTPError` have a ``response`` attribute
+that provides access to that data.
 
 Customizing which error types to handle
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -17,7 +17,7 @@ First of all, let's define the code we'd like to test:
 
     def get_available_pet_photos():
         petstore = SwaggerClient.from_url(
-            'http://petstore.swagger.io/swagger.json',
+            'http://petstore.swagger.io/v2/swagger.json',
         )
         pets = petstore.pet.findPetsByStatus(status=['available']).response(
             timeout=0.5,

--- a/tests/http_future/HttpFuture/response_test.py
+++ b/tests/http_future/HttpFuture/response_test.py
@@ -41,7 +41,23 @@ def fallback_result():
     return mock.Mock(name='fallback result')
 
 
+@pytest.mark.parametrize(
+    'fallback_result',
+    (None, False, [], (), object()),
+)
 def test_fallback_result(fallback_result, mock_future_adapter, mock_operation, http_future):
+    mock_future_adapter.result.side_effect = BravadoTimeoutError()
+    mock_operation.swagger_spec.config = {
+        'bravado': BravadoConfig.from_config_dict({'disable_fallback_results': False})
+    }
+
+    response = http_future.response(fallback_result=fallback_result)
+
+    assert response.result is fallback_result
+    assert response.metadata.is_fallback_result is True
+
+
+def test_fallback_result_callable(fallback_result, mock_future_adapter, mock_operation, http_future):
     mock_future_adapter.result.side_effect = BravadoTimeoutError()
     mock_operation.swagger_spec.config = {
         'bravado': BravadoConfig.from_config_dict({'disable_fallback_results': False})


### PR DESCRIPTION
So I wanted to try out how it would look like if we supported non-callable fallback results, and it's really a very small change. It seems nicer to use and less error prone in the common case.

Do we expect the `callable(fallback_result)` to be enough to reliably identify the two cases? I wasn't able to come up with an example where that wouldn't be the case, but I'd like to hear your input.

Also, do you feel we're in a place where we can commit to these API? Or should we wait with removing the warnings?