### PR TITLE
Add connection error support

### DIFF
--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -2,6 +2,13 @@
 from six import with_metaclass
 
 try:
+    from builtins import ConnectionError as base_connection_error
+except ImportError:
+    # ConnectionError was introduced in python 3.3+
+    base_connection_error = OSError
+
+
+try:
     from builtins import TimeoutError as base_timeout_error
 except ImportError:
     # TimeoutError was introduced in python 3.3+
@@ -333,6 +340,10 @@ class HTTPNetworkAuthenticationRequired(HTTPServerError):
 
 
 class BravadoTimeoutError(base_timeout_error):
+    pass
+
+
+class BravadoConnectionError(base_connection_error):
     pass
 
 

--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
+from six import with_metaclass
+
 try:
-    from builtins import TimeoutError as base_exception
+    from builtins import TimeoutError as base_timeout_error
 except ImportError:
     # TimeoutError was introduced in python 3.3+
-    base_exception = Exception
+    base_timeout_error = OSError
 
-
-from six import with_metaclass
 
 # Dictionary of HTTP status codes to exception classes
 status_map = {}
@@ -332,7 +332,7 @@ class HTTPNetworkAuthenticationRequired(HTTPServerError):
     status_code = 511
 
 
-class BravadoTimeoutError(base_exception):
+class BravadoTimeoutError(base_timeout_error):
     pass
 
 

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -8,6 +8,8 @@ import fido.exceptions
 import requests
 import requests.structures
 import six
+import twisted.internet.error
+import twisted.web.client
 from bravado_core.response import IncomingResponse
 from yelp_bytes import to_bytes
 
@@ -167,6 +169,12 @@ class FidoFutureAdapter(FutureAdapter):
     """
 
     timeout_errors = (fido.exceptions.HTTPTimeoutError,)
+    connection_errors = (
+        fido.exceptions.TCPConnectionError,
+        twisted.internet.error.ConnectingCancelledError,
+        twisted.internet.error.DNSLookupError,
+        twisted.web.client.RequestNotSent,
+    )
 
     def __init__(self, eventual_result):
         self._eventual_result = eventual_result

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -166,7 +166,7 @@ class FidoFutureAdapter(FutureAdapter):
     retrieve results.
     """
 
-    timeout_errors = [fido.exceptions.HTTPTimeoutError]
+    timeout_errors = (fido.exceptions.HTTPTimeoutError,)
 
     def __init__(self, eventual_result):
         self._eventual_result = eventual_result

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -46,14 +46,19 @@ class FutureAdapter(object):
     timeout_errors = ()
 
     def _raise_error(self, base_exception_class, class_name_suffix, exception):
-        error_type = type(
+        error = type(
             '{}{}'.format(self.__class__.__name__, class_name_suffix),
             (exception.__class__, base_exception_class),
-            dict(),
-        )
+            dict(
+                # Small hack to allow all exceptions to be generated even if they have parameters in the signature
+                exception.__dict__,
+                __init__=lambda *args, **kwargs: None,
+            ),
+        )()
+
         six.reraise(
-            error_type,
-            error_type(*exception.args),
+            error.__class__,
+            error,
             sys.exc_info()[2],
         )
 

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -211,7 +211,7 @@ class RequestsFutureAdapter(FutureAdapter):
     HTTP calls with the Requests library in a future-y sort of way.
     """
 
-    timeout_errors = [requests.exceptions.ReadTimeout]
+    timeout_errors = (requests.exceptions.ReadTimeout,)
 
     def __init__(self, session, request, misc_options):
         """Kicks API call for Requests client

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -212,6 +212,7 @@ class RequestsFutureAdapter(FutureAdapter):
     """
 
     timeout_errors = (requests.exceptions.ReadTimeout,)
+    connection_errors = (requests.exceptions.ConnectionError,)
 
     def __init__(self, session, request, misc_options):
         """Kicks API call for Requests client

--- a/tests/http_future/HttpFuture/conftest.py
+++ b/tests/http_future/HttpFuture/conftest.py
@@ -7,4 +7,8 @@ from bravado.http_future import FutureAdapter
 
 @pytest.fixture
 def mock_future_adapter():
-    return mock.Mock(spec=FutureAdapter, timeout_errors=None)
+    return mock.Mock(
+        spec=FutureAdapter,
+        timeout_errors=None,
+        connection_errors=None,
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-import socket
 import time
-from contextlib import closing
 from multiprocessing import Process
 
 import bottle
@@ -243,6 +241,5 @@ def swagger_http_server():
 
 @pytest.fixture(scope='session')
 def not_answering_http_server():
-    with closing(socket.socket(socket.AF_INET)) as s:
-        s.bind(('', 0))
-        yield 'http://localhost:{port}'.format(port=s.getsockname()[1])
+    # Nobody could listen on such address, so TCP 3 way handshake will fail
+    yield 'http://0.0.0.0'

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+import socket
 import time
+from contextlib import closing
 from multiprocessing import Process
 
 import bottle
@@ -124,6 +126,27 @@ SWAGGER_SPEC_DICT = {
                 },
             },
         },
+        '/sleep': {
+            'get': {
+                'operationId': 'sleep',
+                'produces': ['application/json'],
+                'parameters': [
+                    {
+                        'in': 'query',
+                        'name': 'sec',
+                        'type': 'number',
+                        'format': 'float',
+                        'required': True,
+                    }
+                ],
+                'responses': {
+                    '200': {
+                        'description': 'HTTP/200',
+                        'schema': {'$ref': '#/definitions/api_response'},
+                    },
+                },
+            },
+        },
     },
 }
 
@@ -216,3 +239,10 @@ def swagger_http_server():
         yield server_address
     finally:
         web_service_process.terminate()
+
+
+@pytest.fixture(scope='session')
+def not_answering_http_server():
+    with closing(socket.socket(socket.AF_INET)) as s:
+        s.bind(('', 0))
+        yield 'http://localhost:{port}'.format(port=s.getsockname()[1])

--- a/tests/integration/fido_client_test.py
+++ b/tests/integration/fido_client_test.py
@@ -4,11 +4,15 @@ from bravado.fido_client import FidoFutureAdapter
 from tests.integration import requests_client_test
 
 
-class TestServerFidoClient(requests_client_test.TestServerRequestsClient):
+class TestServerFidoClient(requests_client_test.ServerClientGeneric):
 
     http_client_type = FidoClient
     http_future_adapter_type = FidoFutureAdapter
+    connection_errors_exceptions = set()
 
     @classmethod
     def encode_expected_response(cls, response):
         return response
+
+    def cancel_http_future(self, http_future):
+        http_future.future._eventual_result.cancel()

--- a/tests/integration/fido_client_test.py
+++ b/tests/integration/fido_client_test.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+import fido.exceptions
+import twisted.internet.error
+import twisted.web.client
+
 from bravado.fido_client import FidoClient
 from bravado.fido_client import FidoFutureAdapter
 from tests.integration import requests_client_test
@@ -8,7 +12,12 @@ class TestServerFidoClient(requests_client_test.ServerClientGeneric):
 
     http_client_type = FidoClient
     http_future_adapter_type = FidoFutureAdapter
-    connection_errors_exceptions = set()
+    connection_errors_exceptions = {
+        fido.exceptions.TCPConnectionError(),
+        twisted.internet.error.ConnectingCancelledError('address'),
+        twisted.internet.error.DNSLookupError(),
+        twisted.web.client.RequestNotSent(),
+    }
 
     @classmethod
     def encode_expected_response(cls, response):

--- a/tests/integration/requests_client_test.py
+++ b/tests/integration/requests_client_test.py
@@ -10,6 +10,7 @@ from msgpack import packb
 from msgpack import unpackb
 
 from bravado.client import SwaggerClient
+from bravado.exception import BravadoConnectionError
 from bravado.exception import BravadoTimeoutError
 from bravado.requests_client import RequestsClient
 from bravado.requests_client import RequestsFutureAdapter
@@ -27,6 +28,7 @@ class ServerClientGeneric:
 
     http_client_type = None
     http_future_adapter_type = None
+    connection_errors_exceptions = None
 
     @classmethod
     def setup_class(cls):
@@ -34,6 +36,8 @@ class ServerClientGeneric:
             raise RuntimeError('Define http_client_type for {}'.format(cls.__name__))
         if cls.http_future_adapter_type is None:
             raise RuntimeError('Define http_future_adapter_type for {}'.format(cls.__name__))
+        if cls.connection_errors_exceptions is None:
+            raise RuntimeError('Define connection_errors_exceptions for {}'.format(cls.__name__))
         cls.http_client = cls.http_client_type()
 
     @classmethod
@@ -42,6 +46,9 @@ class ServerClientGeneric:
             return response.decode('utf-8')
         else:
             return str(response)
+
+    def cancel_http_future(self, http_future):
+        pass
 
     @pytest.fixture
     def swagger_client(self, swagger_http_server):
@@ -226,11 +233,71 @@ class ServerClientGeneric:
                 }).result(timeout=0.01)
             assert isinstance(excinfo.value, BravadoTimeoutError)
 
+    def test_connection_errors_are_thrown_as_BravadoConnectionError(self, not_answering_http_server):
+        if not self.http_future_adapter_type.connection_errors:
+            pytest.skip('{} does NOT defines connection_errors'.format(self.http_future_adapter_type))
+
+        with pytest.raises(BravadoConnectionError):
+            self.http_client.request({
+                'method': 'GET',
+                'url': '{server_address}/sleep?sec=0.1'.format(server_address=not_answering_http_server),
+                'params': {},
+                'connect_timeout': 0.001,
+                'timeout': 0.01,
+            }).result(timeout=1)
+
+    def test_connection_errors_exceptions_contains_all_future_adapter_connection_errors(self):
+        assert set(
+            type(e) for e in self.connection_errors_exceptions
+        ) == set(self.http_future_adapter_type.connection_errors)
+
+    def test_connection_errors_are_catchable_with_original_exception_types(
+        self, not_answering_http_server,
+    ):
+        for expected_exception in self.connection_errors_exceptions:
+            with pytest.raises(type(expected_exception)) as excinfo:
+                http_future = self.http_client.request({
+                    'method': 'GET',
+                    'url': not_answering_http_server,
+                    'params': {},
+                })
+                # Finding a way to force all the http clients to raise
+                # the expected exception while sending the real request is hard
+                # so we're mocking the future in order to throw the expected
+                # exception so we can validate that the exception is catchable
+                # with the original exception type too
+                self.cancel_http_future(http_future)
+                http_future.future.result = mock.Mock(
+                    side_effect=expected_exception,
+                )
+                http_future.result(timeout=0.1)
+
+            # check that the raised exception is catchable as BravadoConnectionError too
+            assert isinstance(excinfo.value, BravadoConnectionError)
+
+    def test_swagger_client_connection_errors_are_thrown_as_BravadoConnectionError(
+        self, not_answering_http_server, swagger_client, result_getter,
+    ):
+        if not self.http_future_adapter_type.connection_errors:
+            pytest.skip('{} does NOT defines connection_errors'.format(self.http_future_adapter_type))
+
+        # override api url to communicate with a non responding http server
+        swagger_client.swagger_spec.api_url = not_answering_http_server
+        with pytest.raises(BravadoConnectionError):
+            result_getter(
+                swagger_client.json.get_json(_request_options={
+                    'connect_timeout': 0.001,
+                    'timeout': 0.01,
+                }),
+                timeout=0.1,
+            )
+
 
 class TestServerRequestsClient(ServerClientGeneric):
 
     http_client_type = RequestsClient
     http_future_adapter_type = RequestsFutureAdapter
+    connection_errors_exceptions = set()
 
     def test_timeout_errors_are_catchable_as_requests_timeout(self, swagger_http_server):
         with pytest.raises(requests.exceptions.Timeout):
@@ -243,6 +310,7 @@ class TestServerRequestsClient(ServerClientGeneric):
 
 class FakeRequestsFutureAdapter(RequestsFutureAdapter):
     timeout_errors = []
+    connection_errors = []
 
 
 class FakeRequestsClient(RequestsClient):
@@ -259,6 +327,7 @@ class TestServerRequestsClientFake(ServerClientGeneric):
 
     http_client_type = FakeRequestsClient
     http_future_adapter_type = FakeRequestsFutureAdapter
+    connection_errors_exceptions = set()
 
     def test_timeout_error_not_throws_BravadoTimeoutError_if_no_timeout_errors_specified(self, swagger_http_server):
         try:

--- a/tests/integration/requests_client_test.py
+++ b/tests/integration/requests_client_test.py
@@ -297,7 +297,9 @@ class TestServerRequestsClient(ServerClientGeneric):
 
     http_client_type = RequestsClient
     http_future_adapter_type = RequestsFutureAdapter
-    connection_errors_exceptions = set()
+    connection_errors_exceptions = {
+        requests.exceptions.ConnectionError(),
+    }
 
     def test_timeout_errors_are_catchable_as_requests_timeout(self, swagger_http_server):
         with pytest.raises(requests.exceptions.Timeout):


### PR DESCRIPTION
The main objective of this PR is to provide support to `ConnectionError`s as is currently provided for `TimeoutError`s.
This aims to address also @bplotnick suggestions in PR #346.

Details of this PR code changes

1. Integration tests base class is no longer `TestServerRequestsClient`. This is intended done in order to move the base integration tests suite into `bravado.testing` module so external http clients (ie. bravado-asyncio) could be able to run the same tests that we run for the http clients provided by bravado.
NOTE: moving integration tests into `bravado.testing` is not addressed here,  a new PR will be provided in the future
2. changed the way that exceptions are raised:
 * Timeout classes are not saved as future attribute. This is done as futures are created for every request the timeout class was being created _every time_ anyway and because it could be possible that classes are not _compatible_ each others (ie. class 1 and class 2 requires different arguments to be allocated and the new class extends both of them). This was not an issue until now as `timeout_errors` contained a single item, but with connection errors (at least with fido client) we have more that one exception class
 * Re-raising an exception uses an hack to make sure that we'll be able to instantiate the error class without changing the properties (attributes and methods) that the original exception class provides