### PR TITLE
Making requests_client.py's Authenticator URL matches() port-tolerant

### DIFF
--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 class Authenticator(object):
     """Authenticates requests.
 
-    :param host: Host to authenticate for.
+    :param host: Host to authenticate for. In some case
     """
 
     def __init__(self, host):
@@ -33,10 +33,11 @@ class Authenticator(object):
         """Returns true if this authenticator applies to the given url.
 
         :param url: URL to check.
-        :return: True if matches host, port and scheme, False otherwise.
+        :return: True if matches host, False otherwise.
         """
+        host_without_port = self.host.split(':')[0]
         split = urlparse.urlsplit(url)
-        return self.host == split.hostname
+        return host_without_port == split.hostname
 
     def apply(self, request):
         """Apply authentication to a request.


### PR DESCRIPTION
Authenticator::matches()'s documentation advertises full host, scheme and port match, when it just checks for hosts. However when checking hosts, it cannot compare well a configured self.host:withPort (eg. localhost:8080) with the outgoing request full URL's host.
Such a corner case can happen with this piece of code:
http_client.set_basic_auth(
        'localhost:8080',
        BASIC_AUTH_LOGIN, BASIC_AUTH_PASSWORD
    )