### PR TITLE
Add support for customizing TLS/SSL verification for requests client

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,6 +26,7 @@ exclude_patterns = []
 
 pygments_style = 'sphinx'
 
+autoclass_content = 'both'
 
 # -- Options for HTML output ---------------------------------------------
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -73,6 +73,27 @@ Config key                 Type            Description
                                            Default: ``False``
 ========================== =============== ===============================================================
 
+Customizing the HTTP client
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+bravado's default HTTP client uses the excellent `requests library <http://www.python-requests.org/>`_ to make HTTP
+calls. If you'd like to customize its behavior, create a :class:`bravado.requests_client.RequestsClient` instance
+yourself and pass it as ``http_client`` argument to :meth:`.SwaggerClient.from_url` or :meth:`.SwaggerClient.from_spec`.
+
+Currently, you can customize SSL/TLS behavior through the arguments ``ssl_verify`` and ``ssl_cert``. They're identical
+to the ``verify`` and ``cert`` options of the requests library; please check
+`their documentation <http://www.python-requests.org/en/master/user/advanced/#ssl-cert-verification>`_ for usage
+instructions. Note that bravado honors the ``REQUESTS_CA_BUNDLE`` environment variable as well.
+
+Using a different HTTP client
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can use other HTTP clients with bravado; the fido client ships with bravado (:class:`bravado.fido_client.FidoClient`).
+Currently the fido client doesn't support customizing SSL/TLS behavior.
+
+Another well-supported option is `bravado_asyncio <https://github.com/sjaensch/bravado-asyncio>`_, which requires
+Python 3.5+. It supports the same ssl options as the default requests client.
+
 .. _request_configuration:
 
 Per-request Configuration

--- a/tests/requests_client/RequestsClient/separate_params_test.py
+++ b/tests/requests_client/RequestsClient/separate_params_test.py
@@ -8,6 +8,11 @@ def test_separate_params():
         'connect_timeout': 1,
         'timeout': 2
     }
-    sanitized, misc = RequestsClient.separate_params(request_params)
+    sanitized, misc = RequestsClient().separate_params(request_params)
     assert sanitized == {'url': 'http://foo.com'}
-    assert misc == {'connect_timeout': 1, 'timeout': 2}
+    assert misc == {
+        'connect_timeout': 1,
+        'ssl_cert': None,
+        'ssl_verify': True,
+        'timeout': 2,
+    }

--- a/tests/requests_client/RequestsFutureAdapter/header_type_casting_test.py
+++ b/tests/requests_client/RequestsFutureAdapter/header_type_casting_test.py
@@ -3,8 +3,9 @@ from bravado.requests_client import RequestsFutureAdapter
 
 
 def test_result_header_values_are_bytes(session, request):
+    session.merge_environment_settings.return_value = {}
     request.headers = {b'X-Foo': b'hi'}
-    RequestsFutureAdapter(session, request, misc_options={}).result()
+    RequestsFutureAdapter(session, request, misc_options={'ssl_verify': True, 'ssl_cert': None}).result()
 
     # prepare_request should be called with a request containing correctly
     # casted headers (bytestrings should be preserved)


### PR DESCRIPTION
I've manually verified that both disabling SSL (`ssl_verify=False`) as well as a custom CA cert (`ssl_verify='cert.pem'`) work as expected.