### PR TITLE
Add ability to cancel a HttpFuture

### DIFF
--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -218,7 +218,7 @@ class FidoFutureAdapter(FutureAdapter[T]):
         try:
             return self._eventual_result.wait(timeout=timeout)
         except crochet.TimeoutError:
-            self._eventual_result.cancel()
+            self.cancel()
             six.reraise(
                 fido.exceptions.HTTPTimeoutError,
                 fido.exceptions.HTTPTimeoutError(
@@ -228,3 +228,6 @@ class FidoFutureAdapter(FutureAdapter[T]):
                 ),
                 sys.exc_info()[2],
             )
+
+    def cancel(self):
+        self._eventual_result.cancel()

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -230,4 +230,5 @@ class FidoFutureAdapter(FutureAdapter[T]):
             )
 
     def cancel(self):
+        # type: () -> None
         self._eventual_result.cancel()

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -101,6 +101,16 @@ class FutureAdapter(typing.Generic[T]):
             "FutureAdapter must implement 'result' method"
         )
 
+    def cancel(self):
+        # type: () -> None
+        """
+        Must implement a cancel method which terminates any ongoing network
+        request.
+        """
+        raise NotImplementedError(
+            "FutureAdapter must implement 'cancel' method"
+        )
+
 
 def reraise_errors(func):
     # type: (F) -> F
@@ -270,6 +280,10 @@ class HttpFuture(typing.Generic[T]):
             return incoming_response
 
         raise make_http_exception(response=incoming_response)
+
+    def cancel(self):
+        # type: () -> None
+        return self.future.cancel()
 
     @reraise_errors
     def _get_incoming_response(self, timeout=None):

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -107,9 +107,7 @@ class FutureAdapter(typing.Generic[T]):
         Must implement a cancel method which terminates any ongoing network
         request.
         """
-        raise NotImplementedError(
-            "FutureAdapter must implement 'cancel' method"
-        )
+        log.warning('The FutureAdapter class of the HTTP client does not implement cancel(), ignoring the call.')
 
 
 def reraise_errors(func):

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -391,3 +391,7 @@ class RequestsFutureAdapter(FutureAdapter):
             **settings
         )
         return response
+
+    def cancel(self):
+        # type: () -> None
+        pass

--- a/bravado/testing/integration_test.py
+++ b/bravado/testing/integration_test.py
@@ -323,9 +323,6 @@ class IntegrationTestingFixturesMixin(IntegrationTestingServicesAndClient):
         else:
             return str(response)  # pragma: no cover
 
-    def cancel_http_future(self, http_future):
-        pass
-
 
 class IntegrationTestsBaseClass(IntegrationTestingFixturesMixin):
     def test_fetch_specs(self, swagger_http_server):
@@ -534,7 +531,7 @@ class IntegrationTestsBaseClass(IntegrationTestingFixturesMixin):
                     'url': not_answering_http_server,
                     'params': {},
                 })
-                self.cancel_http_future(http_future)
+                http_future.cancel()
 
                 # Finding a way to force all the http clients to raise
                 # the expected exception while sending the real request is hard

--- a/tests/fido_client/FidoFutureAdapter/result_test.py
+++ b/tests/fido_client/FidoFutureAdapter/result_test.py
@@ -15,6 +15,14 @@ def test_eventual_result_not_cancelled():
     assert mock_eventual_result.cancel.called is False
 
 
+def test_cancel_calls_eventual_result():
+    mock_eventual_result = Mock()
+    adapter = FidoFutureAdapter(mock_eventual_result)
+
+    adapter.cancel()
+    assert mock_eventual_result.cancel.called is True
+
+
 def test_eventual_result_cancelled_on_exception():
     mock_eventual_result = Mock(wait=Mock(side_effect=crochet.TimeoutError()))
     adapter = FidoFutureAdapter(mock_eventual_result)

--- a/tests/http_future/HttpFuture/cancel_test.py
+++ b/tests/http_future/HttpFuture/cancel_test.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+import mock
+import pytest
+
+from bravado.http_future import FutureAdapter
+from bravado.http_future import HttpFuture
+
+
+@pytest.fixture
+def mock_log():
+    with mock.patch('bravado.http_future.log') as mock_log:
+        yield mock_log
+
+
+class MyFutureAdapter(FutureAdapter):
+    pass
+
+
+def test_cancel():
+    mock_future_adapter = mock.Mock()
+    future = HttpFuture(future=mock_future_adapter, response_adapter=None)
+    future.cancel()
+
+    assert mock_future_adapter.cancel.call_count == 1
+
+
+def test_cancel_is_backwards_compatible(mock_log):
+    future_adapter = MyFutureAdapter()
+    future = HttpFuture(future=future_adapter, response_adapter=None)
+    future.cancel()
+
+    assert mock_log.warning.call_count == 1

--- a/tests/integration/fido_client_test.py
+++ b/tests/integration/fido_client_test.py
@@ -22,6 +22,3 @@ class TestServerFidoClient(IntegrationTestsBaseClass):
     @classmethod
     def encode_expected_response(cls, response):
         return response
-
-    def cancel_http_future(self, http_future):
-        http_future.future._eventual_result.cancel()


### PR DESCRIPTION
Currently there is no way to do so - the workaround would be to call `result(timeout=0)`, but this might raise an exception, and is potentially costly due to all sorts of response processing.