### PR TITLE
Fix Python 3.5 runtime issues due to typing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,6 @@ exclude_lines =
     raise AssertionError
     raise NotImplementedError
     if __name__ == .__main__.:
-    if typing.TYPE_CHECKING:
+    if getattr(typing, 'TYPE_CHECKING', False):
     pragma: no cover
     @bottle.(get|post|route)

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ matrix:
   - env: TOXENV=py27-fido-requests2dot7
 
   - env: TOXENV=py35-default
-    python: "3.5"
+    # we'll use Python 3.5.0 here to make sure we don't use any typing
+    # features that break on older Python 3.5 releases.
+    python: "3.5.0"
   - env: TOXENV=py35-fido
     python: "3.5"
 

--- a/bravado/client.py
+++ b/bravado/client.py
@@ -53,7 +53,7 @@ from bravado_core.spec import Spec
 from six import iteritems
 from six import itervalues
 
-from bravado.config import BravadoConfig
+from bravado.config import bravado_config_from_config_dict
 from bravado.config import RequestConfig
 from bravado.docstring_property import docstring_property
 from bravado.requests_client import RequestsClient
@@ -123,7 +123,7 @@ class SwaggerClient(object):
         config = config or {}
 
         # Apply bravado config defaults
-        bravado_config = BravadoConfig.from_config_dict(config)
+        bravado_config = bravado_config_from_config_dict(config)
         # remove bravado configs from config dict
         for key in set(bravado_config._fields).intersection(set(config)):
             del config[key]

--- a/bravado/config.py
+++ b/bravado/config.py
@@ -28,16 +28,18 @@ CONFIG_DEFAULTS = {
 }
 
 
-class BravadoConfig(
-    typing.NamedTuple(
-        'BravadoConfig',
-        (
-            ('also_return_response', bool),
-            ('disable_fallback_results', bool),
-            ('response_metadata_class', Type[BravadoResponseMetadata]),
-        ),
-    )
-):
+_BravadoConfig = typing.NamedTuple(
+    '_BravadoConfig',
+    (
+        ('also_return_response', bool),
+        ('disable_fallback_results', bool),
+        ('response_metadata_class', Type[BravadoResponseMetadata]),
+    ),
+)
+
+
+class BravadoConfig(_BravadoConfig):
+
     @staticmethod
     def from_config_dict(config):
         # type: (typing.Mapping[str, typing.Any]) -> 'BravadoConfig'

--- a/bravado/config.py
+++ b/bravado/config.py
@@ -8,6 +8,12 @@ from bravado_core.response import IncomingResponse  # noqa: F401
 
 from bravado.response import BravadoResponseMetadata
 
+try:
+    from typing import Type
+except ImportError:
+    # Python 3.5.0 / 3.5.1
+    from typing_extensions import Type
+
 
 log = logging.getLogger(__name__)
 
@@ -28,7 +34,7 @@ class BravadoConfig(
         (
             ('also_return_response', bool),
             ('disable_fallback_results', bool),
-            ('response_metadata_class', typing.Type[BravadoResponseMetadata]),
+            ('response_metadata_class', Type[BravadoResponseMetadata]),
         ),
     )
 ):

--- a/bravado/config.py
+++ b/bravado/config.py
@@ -28,8 +28,8 @@ CONFIG_DEFAULTS = {
 }
 
 
-_BravadoConfig = typing.NamedTuple(
-    '_BravadoConfig',
+BravadoConfig = typing.NamedTuple(
+    'BravadoConfig',
     (
         ('also_return_response', bool),
         ('disable_fallback_results', bool),
@@ -38,21 +38,18 @@ _BravadoConfig = typing.NamedTuple(
 )
 
 
-class BravadoConfig(_BravadoConfig):
-
-    @staticmethod
-    def from_config_dict(config):
-        # type: (typing.Mapping[str, typing.Any]) -> 'BravadoConfig'
-        if config is None:
-            config = {}
-        bravado_config = {key: value for key, value in config.items() if key in BravadoConfig._fields}
-        bravado_config = dict(CONFIG_DEFAULTS, **bravado_config)
-        bravado_config['response_metadata_class'] = _get_response_metadata_class(
-            bravado_config['response_metadata_class'],
-        )
-        return BravadoConfig(
-            **bravado_config
-        )
+def bravado_config_from_config_dict(config_dict):
+    # type: (typing.Mapping[str, typing.Any]) -> 'BravadoConfig'
+    if config_dict is None:
+        config_dict = {}
+    bravado_config = {key: value for key, value in config_dict.items() if key in BravadoConfig._fields}
+    bravado_config = dict(CONFIG_DEFAULTS, **bravado_config)
+    bravado_config['response_metadata_class'] = _get_response_metadata_class(
+        bravado_config['response_metadata_class'],
+    )
+    return BravadoConfig(
+        **bravado_config
+    )
 
 
 class RequestConfig(object):

--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -19,7 +19,7 @@ except ImportError:
     base_timeout_error = OSError
 
 
-if typing.TYPE_CHECKING:
+if getattr(typing, 'TYPE_CHECKING', False):
     T = typing.TypeVar('T')
 
 

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -76,19 +76,17 @@ class FidoResponseAdapter(IncomingResponse):
         # Let's match the requests interface so code dealing with headers continues to work even when
         # you change the HTTP client.
         if not self._headers:
-            self._headers = typing.cast(
-                typing.MutableMapping[typing.Text, typing.Text],
-                requests.structures.CaseInsensitiveDict(),
-            )
+            # using typing.cast here breaks on Python 3.5.1 and 3.5.0
+            self._headers = requests.structures.CaseInsensitiveDict()  # type: ignore
             for header, values in self._delegate.headers.items():
                 # header names are encoded using latin1, while header values are encoded using UTF-8.
                 # We'll take the last entry in the list of values, making sure the latest header sent
                 # takes precedence. The fact that twisted uses lists of strings for values seems to be
                 # an edge case, I couldn't find any documentation or test using more than one entry in
                 # the list of values for a given header.
-                self._headers[header.decode('latin1')] = values[-1].decode('utf8')
+                self._headers[header.decode('latin1')] = values[-1].decode('utf8')  # type: ignore
 
-        return self._headers
+        return self._headers  # type: ignore
 
     def json(self, **_):
         # type: (typing.Any) -> typing.Mapping[typing.Text, typing.Any]

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -20,7 +20,7 @@ from bravado.http_client import HttpClient
 from bravado.http_future import FutureAdapter
 from bravado.http_future import HttpFuture
 
-if typing.TYPE_CHECKING:
+if getattr(typing, 'TYPE_CHECKING', False):
     class _FidoStub(typing.Protocol):
         code = None  # type: int
         body = None  # type: str

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -18,6 +18,7 @@ from bravado_core.unmarshal import unmarshal_schema_object
 from bravado_core.validate import validate_schema_object
 from msgpack import unpackb
 
+from bravado.config import bravado_config_from_config_dict
 from bravado.config import BravadoConfig
 from bravado.config import CONFIG_DEFAULTS
 from bravado.config import RequestConfig
@@ -165,7 +166,7 @@ class HttpFuture(typing.Generic[T]):
         if self.operation:
             return self.operation.swagger_spec.config['bravado']
         else:
-            return BravadoConfig.from_config_dict(CONFIG_DEFAULTS)
+            return bravado_config_from_config_dict(CONFIG_DEFAULTS)
 
     def response(
         self,

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -216,10 +216,10 @@ class HttpFuture(typing.Generic[T]):
             if request_end_time is None:
                 request_end_time = monotonic.monotonic()
             exc_info = []
-            exc_info.extend(typing.cast(
-                typing.List[typing.Union[typing.Type[BaseException], BaseException, typing.Text]],
-                sys.exc_info()[:2],
-            ))
+            # the return values of exc_info are annotated as Optional, but we know they are set in this case.
+            # additionally, we can't use a cast() since that caused a runtime exception on some older versions
+            # of Python 3.5.
+            exc_info.extend(sys.exc_info()[:2])  # type: ignore
             # the Python 2 documentation states that we shouldn't assign the traceback to a local variable,
             # as that would cause a circular reference. We'll store a string representation of the traceback
             # instead.

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -18,7 +18,7 @@ from bravado.http_future import FutureAdapter
 from bravado.http_future import HttpFuture
 
 
-if typing.TYPE_CHECKING:
+if getattr(typing, 'TYPE_CHECKING', False):
     T = typing.TypeVar('T')
 
 

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -275,7 +275,8 @@ class RequestsResponseAdapter(IncomingResponse):
     @property
     def headers(self):
         # type: () -> typing.Mapping[typing.Text, typing.Text]
-        return typing.cast(typing.Mapping[typing.Text, typing.Text], self._delegate.headers)
+        # we don't use typing.cast here since that's broken on Python 3.5.1
+        return self._delegate.headers  # type: ignore
 
     def json(self, **kwargs):
         # type: (typing.Any) -> typing.Mapping[typing.Text, typing.Any]

--- a/bravado/response.py
+++ b/bravado/response.py
@@ -3,7 +3,7 @@ import monotonic
 import typing
 from bravado_core.response import IncomingResponse  # noqa: F401
 
-if typing.TYPE_CHECKING:  # Needed to avoid cyclic import.
+if getattr(typing, 'TYPE_CHECKING', False):  # Needed to avoid cyclic import.
     from bravado.config import RequestConfig  # noqa: F401
 
 

--- a/bravado/warning.py
+++ b/bravado/warning.py
@@ -3,7 +3,7 @@ import warnings
 
 import typing
 
-if typing.TYPE_CHECKING:  # Needed to avoid cyclic import.
+if getattr(typing, 'TYPE_CHECKING', False):  # Needed to avoid cyclic import.
     from bravado.client import CallableOperation  # noqa: F401
 
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ setup(
     extras_require={
         'fido': ['fido >= 4.2.1'],
         ':python_version<"3.5"': ['typing'],
+        ':python_version=="3.5.1"': ['typing_extensions'],
+        ':python_version=="3.5.0"': ['typing_extensions'],
         'integration-tests': [
             'bottle',
             'ephemeral_port_reserve',

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,9 @@ setup(
     extras_require={
         'fido': ['fido >= 4.2.1'],
         ':python_version<"3.5"': ['typing'],
-        ':python_version=="3.5.1"': ['typing_extensions'],
-        ':python_version=="3.5.0"': ['typing_extensions'],
+        # only needed for Python 3.5.0 and 3.5.1, but =="3.5.0" evaluates
+        # to True for all Python 3.5 versions apparently
+        ':python_version=="3.5"': ['typing_extensions'],
         'integration-tests': [
             'bottle',
             'ephemeral_port_reserve',

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -3,6 +3,7 @@ import mock
 import pytest
 
 from bravado.config import _get_response_metadata_class
+from bravado.config import bravado_config_from_config_dict
 from bravado.config import BravadoConfig
 from bravado.config import CONFIG_DEFAULTS
 from bravado.config import RequestConfig
@@ -28,7 +29,7 @@ def test_default_value_for_every_config():
 
 
 def test_empty_config_yields_default_config(processed_default_config):
-    assert BravadoConfig.from_config_dict({}) == processed_default_config
+    assert bravado_config_from_config_dict({}) == processed_default_config
 
 
 def test_config_overrides_default_config(mock_log):
@@ -40,13 +41,13 @@ def test_config_overrides_default_config(mock_log):
     expected_config_dict = config_dict.copy()
     expected_config_dict['response_metadata_class'] = ResponseMetadata
 
-    assert BravadoConfig.from_config_dict(config_dict)._asdict() == expected_config_dict
+    assert bravado_config_from_config_dict(config_dict)._asdict() == expected_config_dict
     assert mock_log.warning.call_count == 0
 
 
 def test_ignore_unknown_configs(processed_default_config):
     config_dict = {'validate_swagger_spec': False}
-    assert BravadoConfig.from_config_dict(config_dict) == processed_default_config
+    assert bravado_config_from_config_dict(config_dict) == processed_default_config
 
 
 def test_get_response_metadata_class_invalid_str(mock_log):

--- a/tests/http_future/HttpFuture/response_test.py
+++ b/tests/http_future/HttpFuture/response_test.py
@@ -3,7 +3,7 @@ import mock
 import pytest
 from bravado_core.response import IncomingResponse
 
-from bravado.config import BravadoConfig
+from bravado.config import bravado_config_from_config_dict
 from bravado.config import RequestConfig
 from bravado.exception import BravadoTimeoutError
 from bravado.exception import ForcedFallbackResultError
@@ -48,7 +48,7 @@ def fallback_result():
 def test_fallback_result(fallback_result, mock_future_adapter, mock_operation, http_future):
     mock_future_adapter.result.side_effect = BravadoTimeoutError()
     mock_operation.swagger_spec.config = {
-        'bravado': BravadoConfig.from_config_dict({'disable_fallback_results': False})
+        'bravado': bravado_config_from_config_dict({'disable_fallback_results': False})
     }
 
     response = http_future.response(fallback_result=fallback_result)
@@ -60,7 +60,7 @@ def test_fallback_result(fallback_result, mock_future_adapter, mock_operation, h
 def test_fallback_result_callable(fallback_result, mock_future_adapter, mock_operation, http_future):
     mock_future_adapter.result.side_effect = BravadoTimeoutError()
     mock_operation.swagger_spec.config = {
-        'bravado': BravadoConfig.from_config_dict({'disable_fallback_results': False})
+        'bravado': bravado_config_from_config_dict({'disable_fallback_results': False})
     }
 
     response = http_future.response(fallback_result=lambda e: fallback_result)
@@ -90,7 +90,7 @@ def test_no_fallback_result_if_not_provided(mock_future_adapter, http_future):
 def test_no_fallback_result_if_config_disabled(mock_future_adapter, mock_operation, http_future):
     mock_future_adapter.result.side_effect = BravadoTimeoutError()
     mock_operation.swagger_spec.config = {
-        'bravado': BravadoConfig.from_config_dict({'disable_fallback_results': True})
+        'bravado': bravado_config_from_config_dict({'disable_fallback_results': True})
     }
 
     with pytest.raises(BravadoTimeoutError):
@@ -103,7 +103,7 @@ def test_force_fallback_result(mock_operation, fallback_result, http_future):
         also_return_response_default=False,
     )
     mock_operation.swagger_spec.config = {
-        'bravado': BravadoConfig.from_config_dict({})
+        'bravado': bravado_config_from_config_dict({})
     }
 
     with mock.patch('bravado.http_future.unmarshal_response', autospec=True):
@@ -120,7 +120,7 @@ def test_no_force_fallback_result_if_disabled(http_future, mock_operation, mock_
         also_return_response_default=False,
     )
     mock_operation.swagger_spec.config = {
-        'bravado': BravadoConfig.from_config_dict({'disable_fallback_results': True})
+        'bravado': bravado_config_from_config_dict({'disable_fallback_results': True})
     }
 
     with mock.patch('bravado.http_future.unmarshal_response', autospec=True):
@@ -131,7 +131,7 @@ def test_no_force_fallback_result_if_disabled(http_future, mock_operation, mock_
 
 def test_custom_response_metadata(mock_operation, http_future):
     mock_operation.swagger_spec.config = {
-        'bravado': BravadoConfig.from_config_dict(
+        'bravado': bravado_config_from_config_dict(
             {'response_metadata_class': 'tests.http_future.HttpFuture.response_test.ResponseMetadata'})
     }
 


### PR DESCRIPTION
We've run into two issues internally:

1. `typing.TYPE_CHECKING` was added in Python 3.5.2, which means master is currently broken on 3.5.1 and 3.5.0.
2. On Ubuntu xenial with Python 3.5.2, several tests fail with `TypeError: descriptor '__subclasses__' of 'type' object needs an argument`. The code that's failing is a cast we do, which does execute at runtime (but where I'd have thought that it is a no-op). This is the code:
    ```python
    typing.cast(
        typing.List[typing.Union[typing.Type[BaseException], BaseException, typing.Text]],
        sys.exc_info()[:2],
   )

I've manually verified that all tests pass on a xenial box.