### PR TITLE
Fix issues with some pre-commit hooks, run mypy as part of tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,20 +2,25 @@ repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     sha: v1.2.0
     hooks:
-    -   id: autopep8-wrapper
-        args:
-        - -i
-        - --ignore=E309,E501
     -   id: check-json
     -   id: check-yaml
     -   id: fix-encoding-pragma
     -   id: debug-statements
     -   id: end-of-file-fixer
-    -   id: flake8
     -   id: name-tests-test
     -   id: trailing-whitespace
     -   id: requirements-txt-fixer
         files: requirements-dev.txt
+-   repo: git://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4.3
+    hooks:
+    -   id: autopep8
+        args: ['-i', '--ignore=E309,E501']
+-   repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.7.6
+    hooks:
+    -   id: flake8
+        exclude: ^docs
 -   repo: git://github.com/asottile/reorder_python_imports
     sha: v1.0.1
     hooks:

--- a/bravado/config.py
+++ b/bravado/config.py
@@ -2,9 +2,9 @@
 import logging
 from importlib import import_module
 
-import typing  # noqa: F401
-from bravado_core.operation import Operation  # noqa: F401
-from bravado_core.response import IncomingResponse  # noqa: F401
+import typing
+from bravado_core.operation import Operation
+from bravado_core.response import IncomingResponse
 
 from bravado.response import BravadoResponseMetadata
 

--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import typing
-from bravado_core.response import IncomingResponse  # noqa: F401
+from bravado_core.response import IncomingResponse
 from six import with_metaclass
 
 try:

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -11,11 +11,11 @@ import six
 import twisted.internet.error
 import twisted.web.client
 import typing
-from bravado_core.operation import Operation  # noqa: F401
+from bravado_core.operation import Operation
 from bravado_core.response import IncomingResponse
 from yelp_bytes import to_bytes
 
-from bravado.config import RequestConfig  # noqa: F401
+from bravado.config import RequestConfig
 from bravado.http_client import HttpClient
 from bravado.http_future import FutureAdapter
 from bravado.http_future import HttpFuture

--- a/bravado/http_client.py
+++ b/bravado/http_client.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-import typing  # noqa: F401
-from bravado_core.operation import Operation  # noqa: F401
+import typing
+from bravado_core.operation import Operation
 
-from bravado.config import RequestConfig  # noqa: F401
-from bravado.http_future import HttpFuture  # noqa: F401
+from bravado.config import RequestConfig
+from bravado.http_future import HttpFuture
 
 APP_FORM = 'application/x-www-form-urlencoded'
 MULT_FORM = 'multipart/form-data'

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -11,9 +11,9 @@ import typing
 from bravado_core.content_type import APP_JSON
 from bravado_core.content_type import APP_MSGPACK
 from bravado_core.exception import MatchingResponseNotFound
-from bravado_core.operation import Operation  # noqa: F401
+from bravado_core.operation import Operation
 from bravado_core.response import get_response_spec
-from bravado_core.response import IncomingResponse  # noqa: F401
+from bravado_core.response import IncomingResponse
 from bravado_core.unmarshal import unmarshal_schema_object
 from bravado_core.validate import validate_schema_object
 from msgpack import unpackb

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -7,12 +7,12 @@ import requests.auth
 import requests.exceptions
 import six
 import typing
-from bravado_core.operation import Operation  # noqa: F401
+from bravado_core.operation import Operation
 from bravado_core.response import IncomingResponse
 from six import iteritems
 from six.moves.urllib import parse as urlparse
 
-from bravado.config import RequestConfig  # noqa: F401
+from bravado.config import RequestConfig
 from bravado.http_client import HttpClient
 from bravado.http_future import FutureAdapter
 from bravado.http_future import HttpFuture

--- a/bravado/response.py
+++ b/bravado/response.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import monotonic
 import typing
-from bravado_core.response import IncomingResponse  # noqa: F401
+from bravado_core.response import IncomingResponse
 
 if getattr(typing, 'TYPE_CHECKING', False):  # Needed to avoid cyclic import.
-    from bravado.config import RequestConfig  # noqa: F401
+    from bravado.config import RequestConfig
 
 
 T = typing.TypeVar('T')

--- a/bravado/testing/integration_test.py
+++ b/bravado/testing/integration_test.py
@@ -8,7 +8,7 @@ import ephemeral_port_reserve
 import pytest
 import requests
 import requests.exceptions
-import typing  # noqa: F401
+import typing
 from bravado_core.content_type import APP_MSGPACK
 from msgpack import packb
 from msgpack import unpackb
@@ -16,8 +16,8 @@ from msgpack import unpackb
 from bravado.client import SwaggerClient
 from bravado.exception import BravadoConnectionError
 from bravado.exception import BravadoTimeoutError
-from bravado.http_client import HttpClient  # noqa: F401
-from bravado.http_future import FutureAdapter  # noqa: F401
+from bravado.http_client import HttpClient
+from bravado.http_future import FutureAdapter
 from bravado.swagger_model import Loader
 
 

--- a/bravado/warning.py
+++ b/bravado/warning.py
@@ -4,7 +4,7 @@ import warnings
 import typing
 
 if getattr(typing, 'TYPE_CHECKING', False):  # Needed to avoid cyclic import.
-    from bravado.client import CallableOperation  # noqa: F401
+    from bravado.client import CallableOperation
 
 
 def warn_for_deprecated_op(op):

--- a/tests/integration/requests_client_test.py
+++ b/tests/integration/requests_client_test.py
@@ -2,7 +2,7 @@
 import mock
 import pytest
 import requests.exceptions
-import typing  # noqa: F401
+import typing
 
 from bravado.exception import BravadoTimeoutError
 from bravado.requests_client import RequestsClient

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35,py36}-{default,fido}, {py27,py35,py36}-fido-requests2dot7, flake8, pre-commit
+envlist = {py27,py35,py36}-{default,fido}, {py27,py35,py36}-fido-requests2dot7, mypy, pre-commit
 
 [testenv]
 deps =
@@ -11,14 +11,8 @@ setenv =
 commands =
     python -m pytest --capture=no {posargs:tests}
 
-[testenv:flake8]
-skip_install = True
-basepython = python2.7
-deps = flake8
-commands =
-    flake8 bravado tests
-
 [testenv:pre-commit]
+skip_install = True
 basepython = python2.7
 deps = pre-commit>=0.12.0
 setenv =


### PR DESCRIPTION
We've run into another issue internally where we wouldn't use the latest flake8. Let's use flake8 from pre-commit hooks only, and let's pin the version  we use (and also pin the autopep8 version too). There's also an optimization in there for creating the pre-commit tox environment faster.

We were also not running mypy locally when executing tests.