### PR TITLE
Fix is_fallback_result, enable type checking for all code

### DIFF
--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -188,7 +188,7 @@ class HttpFuture(typing.Generic[T]):
         :return: A BravadoResponse instance containing the swagger result and response metadata.
         """
         incoming_response = None
-        exc_info = []  # type: typing.List[typing.Union[typing.Type[BaseException], BaseException, typing.Text]]
+        exc_info = None  # type: typing.Optional[typing.List[typing.Union[typing.Type[BaseException], BaseException, typing.Text]]]  # noqa: E501
         request_end_time = None
         if self.request_config.force_fallback_result:
             exceptions_to_catch = tuple(chain(exceptions_to_catch, (ForcedFallbackResultError,)))

--- a/bravado/response.py
+++ b/bravado/response.py
@@ -53,7 +53,7 @@ class BravadoResponseMetadata(typing.Generic[T]):
         swagger_result,  # type: typing.Optional[T]
         start_time,  # type: float
         request_end_time,  # type: float
-        handled_exception_info,  # type: typing.List[typing.Union[typing.Type[BaseException], BaseException, typing.Text]]  # noqa
+        handled_exception_info,  # type: typing.Optional[typing.List[typing.Union[typing.Type[BaseException], BaseException, typing.Text]]]  # noqa
         request_config,  # type: RequestConfig
     ):
         # type: (...) -> None
@@ -102,7 +102,7 @@ class BravadoResponseMetadata(typing.Generic[T]):
     @property
     def is_fallback_result(self):
         # type: () -> bool
-        return self.handled_exception_info is not None
+        return bool(self.handled_exception_info)
 
     @property
     def request_elapsed_time(self):

--- a/bravado/swagger_model.py
+++ b/bravado/swagger_model.py
@@ -4,6 +4,7 @@ import logging
 import os
 import os.path
 
+import typing
 import yaml
 try:
     from yaml import CSafeLoader as SafeLoader
@@ -34,7 +35,7 @@ class FileEventual(object):
 
         def __init__(self, data):
             self.text = data
-            self.headers = {}
+            self.headers = {}  # type: typing.Mapping[str, str]
 
         def json(self):
             return simplejson.loads(self.text.decode('utf-8'))

--- a/bravado/testing/response_mocks.py
+++ b/bravado/testing/response_mocks.py
@@ -1,26 +1,34 @@
 # -*- coding: utf-8 -*-
+import typing
 from bravado_core.response import IncomingResponse
 
+from bravado.config import RequestConfig
 from bravado.exception import BravadoTimeoutError
+from bravado.http_future import _SENTINEL
 from bravado.http_future import FALLBACK_EXCEPTIONS
 from bravado.http_future import SENTINEL
+from bravado.response import BravadoResponse
 from bravado.response import BravadoResponseMetadata
+
+
+T = typing.TypeVar('T')
 
 
 class IncomingResponseMock(IncomingResponse):
     def __init__(self, status_code, **kwargs):
-        self.headers = {}
+        self.headers = {}  # type: typing.Mapping[str, str]
         self.status_code = status_code
         for name, value in kwargs.items():
             setattr(self, name, value)
 
 
-class BravadoResponseMock(object):
+class BravadoResponseMock(typing.Generic[T]):
     """Class that behaves like the :meth:`.HttpFuture.response` method as well as a :class:`.BravadoResponse`.
     Please check the documentation for further information.
     """
 
     def __init__(self, result, metadata=None):
+        # type: (T, typing.Optional[BravadoResponseMetadata[T]]) -> None
         self._result = result
         if metadata:
             self._metadata = metadata
@@ -31,11 +39,17 @@ class BravadoResponseMock(object):
                 start_time=1528733800,
                 request_end_time=1528733801,
                 handled_exception_info=None,
-                request_config=None,
+                request_config=RequestConfig({}, also_return_response_default=False),
             )
 
-    def __call__(self, timeout=None, fallback_result=SENTINEL, exceptions_to_catch=FALLBACK_EXCEPTIONS):
-        return self
+    def __call__(
+        self,
+        timeout=None,  # type: typing.Optional[float]
+        fallback_result=SENTINEL,  # type: typing.Union[_SENTINEL, T, typing.Callable[[BaseException], T]]  # noqa
+        exceptions_to_catch=FALLBACK_EXCEPTIONS,  # type: typing.Tuple[typing.Type[BaseException], ...]
+    ):
+        # type: (...) -> BravadoResponse[T]
+        return self  # type: ignore
 
     @property
     def result(self):
@@ -53,25 +67,52 @@ class FallbackResultBravadoResponseMock(object):
     """
 
     def __init__(self, exception=BravadoTimeoutError(), metadata=None):
+        # type: (BaseException, typing.Optional[BravadoResponseMetadata]) -> None
         self._exception = exception
         if metadata:
             self._metadata = metadata
         else:
             self._metadata = BravadoResponseMetadata(
-                incoming_response=None,
+                incoming_response=IncomingResponse(),
                 swagger_result=None,  # we're going to set it later
                 start_time=1528733800,
                 request_end_time=1528733801,
-                handled_exception_info=(self._exception.__class__, self._exception, 'Traceback'),
-                request_config=None,
+                handled_exception_info=[self._exception.__class__, self._exception, 'Traceback'],
+                request_config=RequestConfig({}, also_return_response_default=False),
             )
 
-    def __call__(self, timeout=None, fallback_result=SENTINEL, exceptions_to_catch=FALLBACK_EXCEPTIONS):
-        assert fallback_result is not SENTINEL, 'You\'re using FallbackResultBravadoResponseMock without a callable ' \
-            'fallback_result. Either provide a callable or use BravadoResponseMock.'
+    @typing.overload
+    def __call__(
+        self,
+        timeout=None,  # type: typing.Optional[float]
+        fallback_result=T,  # type: T
+        exceptions_to_catch=FALLBACK_EXCEPTIONS,  # type: typing.Tuple[typing.Type[BaseException], ...]
+    ):
+        # type: (...) -> BravadoResponse[T]
+        pass
+
+    @typing.overload
+    def __call__(
+        self,
+        timeout=None,  # type: typing.Optional[float]
+        fallback_result=lambda x: None,  # typing.Callable[[BaseException], T]
+        exceptions_to_catch=FALLBACK_EXCEPTIONS,  # type: typing.Tuple[typing.Type[BaseException], ...]
+    ):
+        # type: (...) -> BravadoResponse[T]
+        pass
+
+    def __call__(
+        self,
+        timeout=None,  # type: typing.Optional[float]
+        fallback_result=SENTINEL,  # type: typing.Union[_SENTINEL, T, typing.Callable[[BaseException], T]]  # noqa
+        exceptions_to_catch=FALLBACK_EXCEPTIONS,  # type: typing.Tuple[typing.Type[BaseException], ...]
+    ):
+        # type: (...) -> BravadoResponse[T]
+        assert not isinstance(fallback_result, _SENTINEL), 'You\'re using FallbackResultBravadoResponseMock without' \
+            ' a fallback_result. Either provide one or use BravadoResponseMock.'
         self._fallback_result = fallback_result(self._exception) if callable(fallback_result) else fallback_result
         self._metadata._swagger_result = self._fallback_result
-        return self
+        return self  # type: ignore
 
     @property
     def result(self):

--- a/bravado/testing/response_mocks.py
+++ b/bravado/testing/response_mocks.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import typing
 from bravado_core.response import IncomingResponse
+from typing_extensions import overload  # typing.overload won't work on Python 3.5.0/3.5.1
 
 from bravado.config import RequestConfig
 from bravado.exception import BravadoTimeoutError
@@ -81,7 +82,7 @@ class FallbackResultBravadoResponseMock(object):
                 request_config=RequestConfig({}, also_return_response_default=False),
             )
 
-    @typing.overload
+    @overload
     def __call__(
         self,
         timeout=None,  # type: typing.Optional[float]
@@ -91,7 +92,7 @@ class FallbackResultBravadoResponseMock(object):
         # type: (...) -> BravadoResponse[T]
         pass
 
-    @typing.overload
+    @overload  # noqa: F811
     def __call__(
         self,
         timeout=None,  # type: typing.Optional[float]
@@ -101,7 +102,7 @@ class FallbackResultBravadoResponseMock(object):
         # type: (...) -> BravadoResponse[T]
         pass
 
-    def __call__(
+    def __call__(  # noqa: F811
         self,
         timeout=None,  # type: typing.Optional[float]
         fallback_result=SENTINEL,  # type: typing.Union[_SENTINEL, T, typing.Callable[[BaseException], T]]  # noqa

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,18 +8,16 @@ check_untyped_defs = True
 disallow_untyped_defs = True
 
 [mypy-bravado.client.*]
-check_untyped_defs = False
 disallow_untyped_defs = False
+
 [mypy-bravado.docstring_property.*]
-check_untyped_defs = False
 disallow_untyped_defs = False
+
 [mypy-bravado.swagger_model.*]
-check_untyped_defs = False
 disallow_untyped_defs = False
+
 [mypy-bravado.testing.*]
-check_untyped_defs = False
 disallow_untyped_defs = False
 
 [mypy-tests.*]
-check_untyped_defs = False
 disallow_untyped_defs = False

--- a/setup.py
+++ b/setup.py
@@ -43,13 +43,11 @@ setup(
         'six',
         'simplejson',
         'monotonic',
+        'typing_extensions',
     ],
     extras_require={
         'fido': ['fido >= 4.2.1'],
         ':python_version<"3.5"': ['typing'],
-        # only needed for Python 3.5.0 and 3.5.1, but =="3.5.0" evaluates
-        # to True for all Python 3.5 versions apparently
-        ':python_version=="3.5"': ['typing_extensions'],
         'integration-tests': [
             'bottle',
             'ephemeral_port_reserve',

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -49,8 +49,8 @@ def test_also_return_response(mock_spec):
 @pytest.mark.xfail
 class SwaggerClientTest(unittest.TestCase):
 
-    def test_from_dict(self):
-        client_stub = SwaggerClient.from_dict(self.resource_listing)
+    def test_from_spec(self):
+        client_stub = SwaggerClient.from_spec(self.resource_listing)
         assert isinstance(client_stub, SwaggerClient)
 
     @httpretty.activate
@@ -79,7 +79,7 @@ class SwaggerClientTest(unittest.TestCase):
 
     @httpretty.activate
     def test_headers(self):
-        self.uut = SwaggerClient.from_resource_listing(self.resource_listing)
+        self.uut = SwaggerClient.from_spec(self.resource_listing)
         httpretty.register_uri(
             httpretty.GET, "http://swagger.py/swagger-test/pet",
             body='[]')
@@ -90,7 +90,7 @@ class SwaggerClientTest(unittest.TestCase):
 
     @httpretty.activate
     def test_multiple_headers(self):
-        self.uut = SwaggerClient.from_resource_listing(self.resource_listing)
+        self.uut = SwaggerClient.from_spec(self.resource_listing)
         httpretty.register_uri(
             httpretty.GET, "http://swagger.py/swagger-test/pet",
             body='[]')
@@ -287,7 +287,7 @@ class SwaggerClientTest(unittest.TestCase):
                 }
             ]
         }
-        self.uut = SwaggerClient.from_resource_listing(self.resource_listing)
+        self.uut = SwaggerClient.from_spec(self.resource_listing)
 
 
 if __name__ == '__main__':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def processed_default_config(**kwargs):
         'response_metadata_class': BravadoResponseMetadata,
     }
     config.update(**kwargs)
-    return BravadoConfig(**config)
+    return BravadoConfig(**config)  # type: ignore
 
 
 @pytest.fixture

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -4,6 +4,7 @@ import json
 
 import httpretty
 import pytest
+import typing
 import yaml
 
 
@@ -19,7 +20,7 @@ def register_spec(swagger_dict, response_spec=None, spec_type='json'):
         response_specs['200']['schema'] = response_spec
 
     if spec_type == 'yaml':
-        serialize_function = yaml.dump
+        serialize_function = yaml.dump  # type: typing.Callable[[typing.Any], typing.Any]
         content_type = 'application/yaml'
     else:
         serialize_function = json.dumps

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -6,6 +6,7 @@ import httpretty
 import mock
 import pytest
 import requests
+from bravado_core.response import IncomingResponse
 
 from bravado.requests_client import RequestsClient
 
@@ -29,7 +30,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params = self._default_params()
         params['params'] = {'foo': 'bar'}
 
-        resp = client.request(params).result()
+        resp = client.request(params).result()  # type: IncomingResponse
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -46,7 +47,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params = self._default_params()
         params['params'] = {'foo': u'酒場'}
 
-        resp = client.request(params).result()
+        resp = client.request(params).result()  # type: IncomingResponse
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -64,7 +65,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params['data'] = {'foo': 'bar'}
         params['method'] = 'POST'
 
-        resp = client.request(params).result()
+        resp = client.request(params).result()  # type: IncomingResponse
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -85,7 +86,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params = self._default_params()
         params['params'] = {'foo': 'bar'}
 
-        resp = client.request(params).result()
+        resp = client.request(params).result()  # type: IncomingResponse
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -106,7 +107,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params = self._default_params()
         params['params'] = {'foo': 'bar'}
 
-        resp = client.request(params).result()
+        resp = client.request(params).result()  # type: IncomingResponse
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -126,7 +127,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params = self._default_params()
         params['params'] = {'foo': 'bar'}
 
-        resp = client.request(params).result()
+        resp = client.request(params).result()  # type: IncomingResponse
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -147,7 +148,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params['params'] = {'foo': 'bar'}
         params['headers'] = {'Key': 'def456'}
 
-        resp = client.request(params).result()
+        resp = client.request(params).result()  # type: IncomingResponse
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -167,7 +168,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params['params'] = {'foo': 'bar'}
         params['url'] = 'http://hackerz.py'
 
-        resp = client.request(params).result()
+        resp = client.request(params).result()  # type: IncomingResponse
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)

--- a/tests/http_future/HttpFuture/cancel_test.py
+++ b/tests/http_future/HttpFuture/cancel_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import mock
 import pytest
+from bravado_core.response import IncomingResponse
 
 from bravado.http_future import FutureAdapter
 from bravado.http_future import HttpFuture
@@ -18,7 +19,10 @@ class MyFutureAdapter(FutureAdapter):
 
 def test_cancel():
     mock_future_adapter = mock.Mock()
-    future = HttpFuture(future=mock_future_adapter, response_adapter=None)
+    future = HttpFuture(
+        future=mock_future_adapter,
+        response_adapter=IncomingResponse(),
+    )  # type: HttpFuture[None]
     future.cancel()
 
     assert mock_future_adapter.cancel.call_count == 1
@@ -26,7 +30,10 @@ def test_cancel():
 
 def test_cancel_is_backwards_compatible(mock_log):
     future_adapter = MyFutureAdapter()
-    future = HttpFuture(future=future_adapter, response_adapter=None)
+    future = HttpFuture(
+        future=future_adapter,
+        response_adapter=IncomingResponse(),
+    )  # type: HttpFuture[None]
     future.cancel()
 
     assert mock_log.warning.call_count == 1

--- a/tests/http_future/HttpFuture/response_test.py
+++ b/tests/http_future/HttpFuture/response_test.py
@@ -48,7 +48,7 @@ def fallback_result():
 def test_fallback_result(fallback_result, mock_future_adapter, mock_operation, http_future):
     mock_future_adapter.result.side_effect = BravadoTimeoutError()
     mock_operation.swagger_spec.config = {
-        'bravado': bravado_config_from_config_dict({'disable_fallback_results': False})
+        'bravado': bravado_config_from_config_dict({'disable_fallback_results': False}),
     }
 
     response = http_future.response(fallback_result=fallback_result)
@@ -60,7 +60,7 @@ def test_fallback_result(fallback_result, mock_future_adapter, mock_operation, h
 def test_fallback_result_callable(fallback_result, mock_future_adapter, mock_operation, http_future):
     mock_future_adapter.result.side_effect = BravadoTimeoutError()
     mock_operation.swagger_spec.config = {
-        'bravado': bravado_config_from_config_dict({'disable_fallback_results': False})
+        'bravado': bravado_config_from_config_dict({'disable_fallback_results': False}),
     }
 
     response = http_future.response(fallback_result=lambda e: fallback_result)
@@ -68,6 +68,16 @@ def test_fallback_result_callable(fallback_result, mock_future_adapter, mock_ope
     assert response.result == fallback_result
     assert response.metadata.is_fallback_result is True
     assert response.metadata.handled_exception_info[0] is BravadoTimeoutError
+
+
+def test_no_is_fallback_result_if_no_exceptions(http_future, mock_operation):
+    mock_operation.swagger_spec.config = {
+        'bravado': bravado_config_from_config_dict({'disable_fallback_results': False}),
+    }
+
+    with mock.patch('bravado.http_future.unmarshal_response'):
+        response = http_future.response()
+    assert response.metadata.is_fallback_result is False
 
 
 def test_no_fallback_result_if_not_in_exceptions_to_catch(fallback_result, mock_future_adapter, http_future):
@@ -90,7 +100,7 @@ def test_no_fallback_result_if_not_provided(mock_future_adapter, http_future):
 def test_no_fallback_result_if_config_disabled(mock_future_adapter, mock_operation, http_future):
     mock_future_adapter.result.side_effect = BravadoTimeoutError()
     mock_operation.swagger_spec.config = {
-        'bravado': bravado_config_from_config_dict({'disable_fallback_results': True})
+        'bravado': bravado_config_from_config_dict({'disable_fallback_results': True}),
     }
 
     with pytest.raises(BravadoTimeoutError):
@@ -120,7 +130,7 @@ def test_no_force_fallback_result_if_disabled(http_future, mock_operation, mock_
         also_return_response_default=False,
     )
     mock_operation.swagger_spec.config = {
-        'bravado': bravado_config_from_config_dict({'disable_fallback_results': True})
+        'bravado': bravado_config_from_config_dict({'disable_fallback_results': True}),
     }
 
     with mock.patch('bravado.http_future.unmarshal_response', autospec=True):
@@ -132,7 +142,7 @@ def test_no_force_fallback_result_if_disabled(http_future, mock_operation, mock_
 def test_custom_response_metadata(mock_operation, http_future):
     mock_operation.swagger_spec.config = {
         'bravado': bravado_config_from_config_dict(
-            {'response_metadata_class': 'tests.http_future.HttpFuture.response_test.ResponseMetadata'})
+            {'response_metadata_class': 'tests.http_future.HttpFuture.response_test.ResponseMetadata'}),
     }
 
     with mock.patch('bravado.http_future.unmarshal_response'):

--- a/tests/http_future/HttpFuture/result_test.py
+++ b/tests/http_future/HttpFuture/result_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+import typing
 from bravado_core.operation import Operation
 from bravado_core.response import IncomingResponse
 from mock import Mock
@@ -15,7 +16,8 @@ def test_200_get_swagger_spec(mock_future_adapter):
     response_adapter_type = Mock(return_value=response_adapter_instance)
     http_future = HttpFuture(
         future=mock_future_adapter,
-        response_adapter=response_adapter_type)
+        response_adapter=response_adapter_type,
+    )  # type: HttpFuture[None]
 
     assert response_adapter_instance == http_future.result()
 
@@ -44,7 +46,8 @@ def test_200_service_call(_, mock_future_adapter):
     http_future = HttpFuture(
         future=mock_future_adapter,
         response_adapter=response_adapter_type,
-        operation=Mock(spec=Operation))
+        operation=Mock(spec=Operation),
+    )  # type: HttpFuture[None]
 
     assert 'hello world' == http_future.result()
 
@@ -61,7 +64,8 @@ def test_400_service_call(mock_unmarshal_response, mock_future_adapter):
     http_future = HttpFuture(
         future=mock_future_adapter,
         response_adapter=response_adapter_type,
-        operation=Mock(spec=Operation))
+        operation=Mock(spec=Operation),
+    )  # type: HttpFuture[None]
 
     with pytest.raises(HTTPError) as excinfo:
         http_future.result()
@@ -82,7 +86,8 @@ def test_also_return_response_true(_, mock_future_adapter):
         future=mock_future_adapter,
         response_adapter=response_adapter_type,
         operation=Mock(spec=Operation),
-        request_config=RequestConfig({}, also_return_response_default=True))
+        request_config=RequestConfig({}, also_return_response_default=True),
+    )  # type: HttpFuture[typing.Tuple[str, IncomingResponse]]
 
     swagger_result, http_response = http_future.result()
 

--- a/tests/response_test.py
+++ b/tests/response_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import mock
 
+from bravado.config import RequestConfig
 from bravado.response import BravadoResponseMetadata
 
 
@@ -12,8 +13,8 @@ def test_response_metadata_times():
             start_time=5,
             request_end_time=10,
             handled_exception_info=None,
-            request_config=None,
-        )
+            request_config=RequestConfig({}, also_return_response_default=False),
+        )  # type: BravadoResponseMetadata[None]
 
     assert metadata.elapsed_time == 6
     assert metadata.request_elapsed_time == 5

--- a/tests/testing/response_mocks_test.py
+++ b/tests/testing/response_mocks_test.py
@@ -3,7 +3,9 @@ import inspect
 
 import mock
 import pytest
+from bravado_core.response import IncomingResponse
 
+from bravado.config import RequestConfig
 from bravado.exception import HTTPServerError
 from bravado.http_future import HttpFuture
 from bravado.response import BravadoResponseMetadata
@@ -19,12 +21,12 @@ def mock_result():
 @pytest.fixture
 def mock_metadata():
     return BravadoResponseMetadata(
-        incoming_response=None,
+        incoming_response=IncomingResponse(),
         swagger_result=None,
         start_time=5,
         request_end_time=6,
         handled_exception_info=None,
-        request_config=None,
+        request_config=RequestConfig({}, also_return_response_default=False),
     )
 
 
@@ -53,6 +55,7 @@ def test_bravado_response_custom_metadata(mock_result, mock_metadata):
 
 
 def test_fallback_result_bravado_response(mock_result):
+    # type: (mock.NonCallableMagicMock) -> None
     response_mock = FallbackResultBravadoResponseMock()
     response = response_mock(fallback_result=mock_result)
 


### PR DESCRIPTION
Fixes #409.

The fix was easy, but the question was why our tests didn't catch it. I've added one. I was also surprised to see that mypy wouldn't complain about this - turns out we weren't checking unannotated code at all. The bulk of this CR is enabling it, and fixing the resulting issues.