### PR TITLE
Make sure response.text returns an unicode string for the fido client

### DIFF
--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -23,7 +23,7 @@ from bravado.http_future import HttpFuture
 if getattr(typing, 'TYPE_CHECKING', False):
     class _FidoStub(typing.Protocol):
         code = None  # type: int
-        body = None  # type: str
+        body = None  # type: bytes
         reason = None  # type: typing.Text
         headers = None  # type: typing.Mapping[bytes, typing.List[bytes]]
 
@@ -56,7 +56,7 @@ class FidoResponseAdapter(IncomingResponse):
     @property
     def text(self):
         # type: () -> typing.Text
-        return self._delegate.body
+        return self._delegate.body.decode('utf-8')  # this is what _delegate.json() does as well
 
     @property
     def raw_bytes(self):
@@ -90,7 +90,6 @@ class FidoResponseAdapter(IncomingResponse):
 
     def json(self, **_):
         # type: (typing.Any) -> typing.Mapping[typing.Text, typing.Any]
-        # TODO: pass the kwargs downstream
         return self._delegate.json()
 
 

--- a/tests/integration/fido_client_test.py
+++ b/tests/integration/fido_client_test.py
@@ -18,7 +18,3 @@ class TestServerFidoClient(IntegrationTestsBaseClass):
         twisted.internet.error.DNSLookupError(),
         twisted.web.client.RequestNotSent(),
     }
-
-    @classmethod
-    def encode_expected_response(cls, response):
-        return response


### PR DESCRIPTION
This is what the requests client does, and how it's documented on the `IncomingResponse` (even though that could be phrased even clearer).

The body annotation was actually wrong on Python 3, which went unnoticed since we don't run mypy in Python 3 mode. I haven't added a run in Python 3 mode to tox.ini yet since there are issues with `exception.py` that we need to fix first.