### PR TITLE
Return binary data for application content types

### DIFF
--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -389,6 +389,9 @@ def unmarshal_response_inner(
             value=content_value,
         )
 
+    if content_type.startswith('application'):
+        return response.raw_bytes
+
     # TODO: Non-json response contents
     return response.text
 

--- a/tests/http_future/unmarshall_response_inner_test.py
+++ b/tests/http_future/unmarshall_response_inner_test.py
@@ -89,6 +89,20 @@ def test_text_content(mock_get_response_spec, empty_swagger_spec, response_spec)
     assert 'Monday' == unmarshal_response_inner(response, op)
 
 
+def test_binary_content(mock_get_response_spec, empty_swagger_spec, response_spec):
+    response = mock.Mock(
+        spec=IncomingResponse,
+        status_code=200,
+        headers={'content-type': 'application/octet-stream'},
+        text='Monday',
+        raw_bytes='SomeBinaryData'
+    )
+
+    mock_get_response_spec.return_value = response_spec
+    op = mock.Mock(swagger_spec=empty_swagger_spec)
+    assert 'SomeBinaryData' == unmarshal_response_inner(response, op)
+
+
 def test_skips_validation(mock_validate_schema_object, mock_get_response_spec, empty_swagger_spec, response_spec):
     empty_swagger_spec.config['validate_responses'] = False
     response = mock.Mock(


### PR DESCRIPTION
This PR modifies the unmarshalling process to return `raw_bytes` when the content type is application. Per the [spec](https://tools.ietf.org/html/rfc6838#section-4.2.5) this content type is used for data to be processed by an application before it is usable by a person, so I believe this is a safe change to make.

Original issue #394 