### PR TITLE
Add AppVeyor support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,34 @@
+version: '{build}'
+image: Visual Studio 2017
+
+environment:
+  matrix:
+  # Available python versions and their locations on https://www.appveyor.com/docs/build-environment/#python
+  - PYTHON: C:\Python27-x64
+    TOXENV: py27-default
+  - PYTHON: C:\Python35-x64
+    TOXENV: py35-default
+  - PYTHON: C:\Python36-x64
+    TOXENV: py36-default
+
+
+build: off
+
+install:
+- cmd: SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+- cmd: pip install tox
+
+before_test:
+- cmd: python --version
+- cmd: pip --version
+- cmd: tox --version
+
+test_script:
+- cmd: >-
+    tox
+
+# Uncomment the following block to enable remote desktop debugging (https://www.appveyor.com/docs/how-to/rdp-to-build-worker/)
+#init:
+#- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#on_failure:
+#- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/bravado/testing/integration_test.py
+++ b/bravado/testing/integration_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import sys
 import time
 from multiprocessing import Process
 
@@ -234,6 +235,10 @@ def sleep_api():
     return sec_to_sleep
 
 
+@pytest.mark.skipif(
+    condition=sys.platform == 'win32',
+    reason='Integration tests fails on windows due to some bottle issue, let\'s ignore them for now',
+)
 class IntegrationTestingServicesAndClient:
     @pytest.fixture(scope='session')
     def swagger_http_server(self):

--- a/tests/swagger_model/load_file_test.py
+++ b/tests/swagger_model/load_file_test.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import os
+import sys
+
 import pytest
 
 from bravado.swagger_model import load_file
@@ -30,5 +33,8 @@ def test_spec_internal_representation_identical():
 
 def test_non_existent_file():
     with pytest.raises(IOError) as excinfo:
-        load_file('test-data/2.0/i_dont_exist.json')
-    assert 'No such file or directory' in str(excinfo.value)
+        load_file(os.path.join('test-data', '2.0', 'i_dont_exist.json'))
+    if sys.platform == "win32":
+        assert 'The system cannot find the file specified' in str(excinfo.value)
+    else:
+        assert 'No such file or directory' in str(excinfo.value)


### PR DESCRIPTION
The goal of this PR is to allow some Windows testing of the bravado library.
At the current stage I'm not able to have integration tests running properly on Windows, that's the reason of the `pytest.mark.skipif` decorator.
I will try to fix it or create an issue to address it (if I'm not able to do it in a timely manner).

This branch windows tests are available on https://ci.appveyor.com/project/macisamuele/bravado/builds/24360624

NOTE: windows tests are green if using the HEAD of bravado-core (https://ci.appveyor.com/project/macisamuele/bravado/builds/24360424)