### PR TITLE
Fix integration tests on Windows

### DIFF
--- a/bravado/testing/integration_test.py
+++ b/bravado/testing/integration_test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import json
-import sys
 import time
 from multiprocessing import Process
 
@@ -235,10 +234,11 @@ def sleep_api():
     return sec_to_sleep
 
 
-@pytest.mark.skipif(
-    condition=sys.platform == 'win32',
-    reason='Integration tests fails on windows due to some bottle issue, let\'s ignore them for now',
-)
+def run_bottle_server(port):
+    """Wrapper function for bottle.run so that the child Python interpreter finds the bottle routes on Windows."""
+    bottle.run(quiet=True, host='localhost', port=port)
+
+
 class IntegrationTestingServicesAndClient:
     @pytest.fixture(scope='session')
     def swagger_http_server(self):
@@ -256,8 +256,8 @@ class IntegrationTestingServicesAndClient:
         port = ephemeral_port_reserve.reserve()
 
         web_service_process = Process(
-            target=bottle.run,
-            kwargs={'quiet': True, 'host': 'localhost', 'port': port},
+            target=run_bottle_server,
+            kwargs={'port': port},
         )
         try:
             web_service_process.start()


### PR DESCRIPTION
Windows doesn't have fork, but spawns a completely fresh Python interpreter when you use `multiprocessing.Process` ([documentation](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods)). This is why that new child interpreter doesn't find the bottle routes and thus returns 404s, since it never imported / ran `integration_test.py`. By executing a small wrapper function from that file we make sure it gets imported, thus fixing the bottle server.