### PR TITLE
Update client classes - set response & future adapter class as class-level vars

### DIFF
--- a/CHANGELOG-MASTER.rst
+++ b/CHANGELOG-MASTER.rst
@@ -4,3 +4,6 @@ Changelog-Master
 *This file will contain the Changelog of the master branch.*
 
 *The content will be used to build the Changelog of the new bravado release.*
+
+Update client classes to have response and future adapter class as a class level attributes.
+This will simplify the custom client class creation - no more need to rewrite the `request` method.

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -133,9 +133,6 @@ class FidoFutureAdapter(FutureAdapter[T]):
         self._eventual_result.cancel()
 
 
-FidoFutureAdapterType = typing.NewType('FidoFutureAdapterType', FutureAdapter)
-
-
 class FidoClient(HttpClient):
     """Fido (Asynchronous) HTTP client implementation.
     """
@@ -166,7 +163,7 @@ class FidoClient(HttpClient):
 
         request_for_twisted = self.prepare_request_for_twisted(request_params)
 
-        future_adapter = self.future_adapter_class(fido.fetch(**request_for_twisted))  # type: FidoFutureAdapter
+        future_adapter = self.future_adapter_class(fido.fetch(**request_for_twisted))  # type: FidoFutureAdapter[T]
 
         return HttpFuture(future_adapter,
                           self.response_adapter_class,

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -93,9 +93,55 @@ class FidoResponseAdapter(IncomingResponse):
         return self._delegate.json()
 
 
+class FidoFutureAdapter(FutureAdapter[T]):
+    """
+    This is just a wrapper for an EventualResult object from crochet.
+    It implements the 'result' method which is needed by our HttpFuture to
+    retrieve results.
+    """
+
+    timeout_errors = (fido.exceptions.HTTPTimeoutError,)
+    connection_errors = (
+        fido.exceptions.TCPConnectionError,
+        twisted.internet.error.ConnectingCancelledError,
+        twisted.internet.error.DNSLookupError,
+        twisted.web.client.RequestNotSent,
+    )
+
+    def __init__(self, eventual_result):
+        # type: (typing.Any) -> None
+        self._eventual_result = eventual_result
+
+    def result(self, timeout=None):
+        # type: (typing.Optional[float]) -> T
+        try:
+            return self._eventual_result.wait(timeout=timeout)
+        except crochet.TimeoutError:
+            self.cancel()
+            six.reraise(
+                fido.exceptions.HTTPTimeoutError,
+                fido.exceptions.HTTPTimeoutError(
+                    'Connection was closed by fido after blocking for '
+                    'timeout={timeout} seconds waiting for the server to '
+                    'send the response'.format(timeout=timeout)
+                ),
+                sys.exc_info()[2],
+            )
+
+    def cancel(self):
+        # type: () -> None
+        self._eventual_result.cancel()
+
+
+FidoFutureAdapterType = typing.NewType('FidoFutureAdapterType', FutureAdapter)
+
+
 class FidoClient(HttpClient):
     """Fido (Asynchronous) HTTP client implementation.
     """
+
+    response_adapter_class = FidoResponseAdapter
+    future_adapter_class = FidoFutureAdapter
 
     def request(
         self,
@@ -120,10 +166,10 @@ class FidoClient(HttpClient):
 
         request_for_twisted = self.prepare_request_for_twisted(request_params)
 
-        future_adapter = FidoFutureAdapter(fido.fetch(**request_for_twisted))  # type: FidoFutureAdapter[T]
+        future_adapter = self.future_adapter_class(fido.fetch(**request_for_twisted))  # type: FidoFutureAdapter
 
         return HttpFuture(future_adapter,
-                          FidoResponseAdapter,
+                          self.response_adapter_class,
                           operation,
                           request_config)
 
@@ -189,43 +235,3 @@ class FidoClient(HttpClient):
                 request_for_twisted[fetch_kwarg] = request_params[fetch_kwarg]
 
         return request_for_twisted
-
-
-class FidoFutureAdapter(FutureAdapter[T]):
-    """
-    This is just a wrapper for an EventualResult object from crochet.
-    It implements the 'result' method which is needed by our HttpFuture to
-    retrieve results.
-    """
-
-    timeout_errors = (fido.exceptions.HTTPTimeoutError,)
-    connection_errors = (
-        fido.exceptions.TCPConnectionError,
-        twisted.internet.error.ConnectingCancelledError,
-        twisted.internet.error.DNSLookupError,
-        twisted.web.client.RequestNotSent,
-    )
-
-    def __init__(self, eventual_result):
-        # type: (typing.Any) -> None
-        self._eventual_result = eventual_result
-
-    def result(self, timeout=None):
-        # type: (typing.Optional[float]) -> T
-        try:
-            return self._eventual_result.wait(timeout=timeout)
-        except crochet.TimeoutError:
-            self.cancel()
-            six.reraise(
-                fido.exceptions.HTTPTimeoutError,
-                fido.exceptions.HTTPTimeoutError(
-                    'Connection was closed by fido after blocking for '
-                    'timeout={timeout} seconds waiting for the server to '
-                    'send the response'.format(timeout=timeout)
-                ),
-                sys.exc_info()[2],
-            )
-
-    def cancel(self):
-        # type: () -> None
-        self._eventual_result.cancel()

--- a/bravado/http_client.py
+++ b/bravado/http_client.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 import typing
 from bravado_core.operation import Operation
+from bravado_core.response import IncomingResponse
 
 from bravado.config import RequestConfig
+from bravado.http_future import FutureAdapter
 from bravado.http_future import HttpFuture
 
 APP_FORM = 'application/x-www-form-urlencoded'
@@ -13,6 +15,9 @@ class HttpClient(object):
     """Interface for a minimal HTTP client that can retrieve Swagger specs
     and perform HTTP calls to fulfill a Swagger operation.
     """
+
+    response_adapter_class = None  # type: typing.ClassVar[IncomingResponse]
+    future_adapter_class = None  # type: typing.ClassVar[typing.Type[FutureAdapter]]
 
     def request(
         self,

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -118,129 +118,6 @@ class BasicAuthenticator(Authenticator):
         return request
 
 
-class RequestsClient(HttpClient):
-    """Synchronous HTTP client implementation.
-    """
-
-    def __init__(self, ssl_verify=True, ssl_cert=None):
-        # type: (bool, typing.Any) -> None
-        """
-        :param ssl_verify: Set to False to disable SSL certificate validation. Provide the path to a
-            CA bundle if you need to use a custom one.
-        :param ssl_cert: Provide a client-side certificate to use. Either a sequence of strings pointing
-            to the certificate (1) and the private key (2), or a string pointing to the combined certificate
-            and key.
-        """
-        self.session = requests.Session()
-        self.authenticator = None  # type: typing.Optional[Authenticator]
-        self.ssl_verify = ssl_verify
-        self.ssl_cert = ssl_cert
-
-    def separate_params(
-        self,
-        request_params,  # type: typing.MutableMapping[str, typing.Any]
-    ):
-        # type: (...) -> typing.Tuple[typing.Mapping[str, typing.Any], typing.Mapping[str, typing.Any]]
-        """Splits the passed in dict of request_params into two buckets.
-
-        - sanitized_params are valid kwargs for constructing a
-          requests.Request(..)
-        - misc_options are things like timeouts which can't be communicated
-          to the Requests library via the requests.Request(...) constructor.
-
-        :param request_params: kitchen sink of request params. Treated as a
-            read-only dict.
-        :returns: tuple(sanitized_params, misc_options)
-        """
-        sanitized_params = copy.copy(request_params)
-        misc_options = {
-            'ssl_verify': self.ssl_verify,
-            'ssl_cert': self.ssl_cert,
-        }
-
-        if 'connect_timeout' in sanitized_params:
-            misc_options['connect_timeout'] = \
-                sanitized_params.pop('connect_timeout')
-
-        if 'timeout' in sanitized_params:
-            misc_options['timeout'] = sanitized_params.pop('timeout')
-
-        return sanitized_params, misc_options
-
-    def request(
-        self,
-        request_params,  # type: typing.MutableMapping[str, typing.Any]
-        operation=None,  # type: typing.Optional[Operation]
-        request_config=None,  # type: typing.Optional[RequestConfig]
-    ):
-        # type: (...) -> HttpFuture[T]
-        """
-        :param request_params: complete request data.
-        :type request_params: dict
-        :param operation: operation that this http request is for. Defaults
-            to None - in which case, we're obviously just retrieving a Swagger
-            Spec.
-        :type operation: :class:`bravado_core.operation.Operation`
-        :param RequestConfig request_config: per-request configuration
-
-        :returns: HTTP Future object
-        :rtype: :class: `bravado_core.http_future.HttpFuture`
-        """
-        sanitized_params, misc_options = self.separate_params(request_params)
-
-        requests_future = RequestsFutureAdapter(
-            self.session,
-            self.authenticated_request(sanitized_params),
-            misc_options,
-        )
-
-        return HttpFuture(
-            requests_future,
-            RequestsResponseAdapter,
-            operation,
-            request_config,
-        )
-
-    def set_basic_auth(
-        self,
-        host,  # type: str
-        username,  # type: typing.Union[bytes, str]
-        password,  # type: typing.Union[bytes, str]
-    ):
-        # type: (...) -> None
-        self.authenticator = BasicAuthenticator(
-            host=host,
-            username=username,
-            password=password,
-        )
-
-    def set_api_key(
-        self,
-        host,  # type: str
-        api_key,  # type: typing.Text
-        param_name=u'api_key',  # type: typing.Text
-        param_in=u'query',  # type: typing.Text
-    ):
-        # type: (...) -> None
-        self.authenticator = ApiKeyAuthenticator(
-            host=host,
-            api_key=api_key,
-            param_name=param_name,
-            param_in=param_in,
-        )
-
-    def authenticated_request(self, request_params):
-        # type: (typing.Mapping[str, typing.Any]) -> requests.Request
-        return self.apply_authentication(requests.Request(**request_params))
-
-    def apply_authentication(self, request):
-        # type: (requests.Request) -> requests.Request
-        if self.authenticator and self.authenticator.matches(request.url):
-            return self.authenticator.apply(request)
-
-        return request
-
-
 class RequestsResponseAdapter(IncomingResponse):
     """Wraps a requests.models.Response object to provide a uniform interface
     to the response innards.
@@ -396,3 +273,129 @@ class RequestsFutureAdapter(FutureAdapter):
     def cancel(self):
         # type: () -> None
         pass
+
+
+class RequestsClient(HttpClient):
+    """Synchronous HTTP client implementation.
+    """
+
+    response_adapter_class = RequestsResponseAdapter
+    future_adapter_class = RequestsFutureAdapter
+
+    def __init__(self, ssl_verify=True, ssl_cert=None):
+        # type: (bool, typing.Any) -> None
+        """
+        :param ssl_verify: Set to False to disable SSL certificate validation. Provide the path to a
+            CA bundle if you need to use a custom one.
+        :param ssl_cert: Provide a client-side certificate to use. Either a sequence of strings pointing
+            to the certificate (1) and the private key (2), or a string pointing to the combined certificate
+            and key.
+        """
+        self.session = requests.Session()
+        self.authenticator = None  # type: typing.Optional[Authenticator]
+        self.ssl_verify = ssl_verify
+        self.ssl_cert = ssl_cert
+
+    def separate_params(
+        self,
+        request_params,  # type: typing.MutableMapping[str, typing.Any]
+    ):
+        # type: (...) -> typing.Tuple[typing.Mapping[str, typing.Any], typing.Mapping[str, typing.Any]]
+        """Splits the passed in dict of request_params into two buckets.
+
+        - sanitized_params are valid kwargs for constructing a
+          requests.Request(..)
+        - misc_options are things like timeouts which can't be communicated
+          to the Requests library via the requests.Request(...) constructor.
+
+        :param request_params: kitchen sink of request params. Treated as a
+            read-only dict.
+        :returns: tuple(sanitized_params, misc_options)
+        """
+        sanitized_params = copy.copy(request_params)
+        misc_options = {
+            'ssl_verify': self.ssl_verify,
+            'ssl_cert': self.ssl_cert,
+        }
+
+        if 'connect_timeout' in sanitized_params:
+            misc_options['connect_timeout'] = \
+                sanitized_params.pop('connect_timeout')
+
+        if 'timeout' in sanitized_params:
+            misc_options['timeout'] = sanitized_params.pop('timeout')
+
+        return sanitized_params, misc_options
+
+    def request(
+        self,
+        request_params,  # type: typing.MutableMapping[str, typing.Any]
+        operation=None,  # type: typing.Optional[Operation]
+        request_config=None,  # type: typing.Optional[RequestConfig]
+    ):
+        # type: (...) -> HttpFuture[T]
+        """
+        :param request_params: complete request data.
+        :type request_params: dict
+        :param operation: operation that this http request is for. Defaults
+            to None - in which case, we're obviously just retrieving a Swagger
+            Spec.
+        :type operation: :class:`bravado_core.operation.Operation`
+        :param RequestConfig request_config: per-request configuration
+
+        :returns: HTTP Future object
+        :rtype: :class: `bravado_core.http_future.HttpFuture`
+        """
+        sanitized_params, misc_options = self.separate_params(request_params)
+
+        requests_future = self.future_adapter_class(
+            self.session,
+            self.authenticated_request(sanitized_params),
+            misc_options,
+        )
+
+        return HttpFuture(
+            requests_future,
+            self.response_adapter_class,
+            operation,
+            request_config,
+        )
+
+    def set_basic_auth(
+        self,
+        host,  # type: str
+        username,  # type: typing.Union[bytes, str]
+        password,  # type: typing.Union[bytes, str]
+    ):
+        # type: (...) -> None
+        self.authenticator = BasicAuthenticator(
+            host=host,
+            username=username,
+            password=password,
+        )
+
+    def set_api_key(
+        self,
+        host,  # type: str
+        api_key,  # type: typing.Text
+        param_name=u'api_key',  # type: typing.Text
+        param_in=u'query',  # type: typing.Text
+    ):
+        # type: (...) -> None
+        self.authenticator = ApiKeyAuthenticator(
+            host=host,
+            api_key=api_key,
+            param_name=param_name,
+            param_in=param_in,
+        )
+
+    def authenticated_request(self, request_params):
+        # type: (typing.Mapping[str, typing.Any]) -> requests.Request
+        return self.apply_authentication(requests.Request(**request_params))
+
+    def apply_authentication(self, request):
+        # type: (requests.Request) -> requests.Request
+        if self.authenticator and self.authenticator.matches(request.url):
+            return self.authenticator.apply(request)
+
+        return request

--- a/tests/integration/requests_client_test.py
+++ b/tests/integration/requests_client_test.py
@@ -35,7 +35,7 @@ class FakeRequestsFutureAdapter(RequestsFutureAdapter):
 
 
 class FakeRequestsClient(RequestsClient):
-    @mock.patch('bravado.requests_client.RequestsFutureAdapter', FakeRequestsFutureAdapter)
+    @mock.patch.object(RequestsClient, 'future_adapter_class', FakeRequestsFutureAdapter)
     def request(self, *args, **kwargs):
         return super(FakeRequestsClient, self).request(*args, **kwargs)
 


### PR DESCRIPTION
Update client classes to have the response and future adapter class as class-level attributes.
This will simplify the custom client class creation - no more need to rewrite the `request` method.

UPD: depends on #427