### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
     # we'll use Python 3.5.0 here to make sure we don't use any typing
     # features that break on older Python 3.5 releases.
     python: "3.5.0"
+    dist: trusty
   - env: TOXENV=py35-fido
     python: "3.5"
 

--- a/CHANGELOG-MASTER.rst
+++ b/CHANGELOG-MASTER.rst
@@ -4,3 +4,5 @@ Changelog-Master
 *This file will contain the Changelog of the master branch.*
 
 *The content will be used to build the Changelog of the new bravado release.*
+
+Rename the `request` and `session` fixtures to prevent the `PytestDeprecationWarning` errors

--- a/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
+++ b/tests/requests_client/RequestsFutureAdapter/build_timeout_test.py
@@ -2,61 +2,61 @@
 from bravado.requests_client import RequestsFutureAdapter
 
 
-def test_no_timeouts(session, request):
+def test_no_timeouts(session_mock, request_mock):
     misc_options = {}
-    future = RequestsFutureAdapter(session, request, misc_options)
+    future = RequestsFutureAdapter(session_mock, request_mock, misc_options)
     assert future.build_timeout(result_timeout=None) is None
 
 
-def test_service_timeout_and_result_timeout_None(session, request):
+def test_service_timeout_and_result_timeout_None(session_mock, request_mock):
     misc_options = dict(timeout=1)
-    future = RequestsFutureAdapter(session, request, misc_options)
+    future = RequestsFutureAdapter(session_mock, request_mock, misc_options)
     assert future.build_timeout(result_timeout=None) == 1
 
 
-def test_no_service_timeout_and_result_timeout_not_None(session, request):
+def test_no_service_timeout_and_result_timeout_not_None(session_mock, request_mock):
     misc_options = {}
-    future = RequestsFutureAdapter(session, request, misc_options)
+    future = RequestsFutureAdapter(session_mock, request_mock, misc_options)
     assert future.build_timeout(result_timeout=1) == 1
 
 
-def test_service_timeout_lt_result_timeout(session, request):
+def test_service_timeout_lt_result_timeout(session_mock, request_mock):
     misc_options = dict(timeout=10)
-    future = RequestsFutureAdapter(session, request, misc_options)
+    future = RequestsFutureAdapter(session_mock, request_mock, misc_options)
     assert future.build_timeout(result_timeout=11) == 11
 
 
-def test_service_timeout_gt_result_timeout(session, request):
+def test_service_timeout_gt_result_timeout(session_mock, request_mock):
     misc_options = dict(timeout=11)
-    future = RequestsFutureAdapter(session, request, misc_options)
+    future = RequestsFutureAdapter(session_mock, request_mock, misc_options)
     assert future.build_timeout(result_timeout=10) == 11
 
 
-def test_service_timeout_None_result_timeout_not_None(session, request):
+def test_service_timeout_None_result_timeout_not_None(session_mock, request_mock):
     misc_options = dict(timeout=None)
-    future = RequestsFutureAdapter(session, request, misc_options)
+    future = RequestsFutureAdapter(session_mock, request_mock, misc_options)
     assert future.build_timeout(result_timeout=10) == 10
 
 
-def test_service_timeout_not_None_result_timeout_None(session, request):
+def test_service_timeout_not_None_result_timeout_None(session_mock, request_mock):
     misc_options = dict(timeout=10)
-    future = RequestsFutureAdapter(session, request, misc_options)
+    future = RequestsFutureAdapter(session_mock, request_mock, misc_options)
     assert future.build_timeout(result_timeout=None) == 10
 
 
-def test_both_timeouts_the_same(session, request):
+def test_both_timeouts_the_same(session_mock, request_mock):
     misc_options = dict(timeout=10)
-    future = RequestsFutureAdapter(session, request, misc_options)
+    future = RequestsFutureAdapter(session_mock, request_mock, misc_options)
     assert future.build_timeout(result_timeout=10) == 10
 
 
-def test_connect_timeout_and_idle_timeout(session, request):
+def test_connect_timeout_and_idle_timeout(session_mock, request_mock):
     misc_options = dict(connect_timeout=1, timeout=11)
-    future = RequestsFutureAdapter(session, request, misc_options)
+    future = RequestsFutureAdapter(session_mock, request_mock, misc_options)
     assert future.build_timeout(result_timeout=None) == (1, 11)
 
 
-def test_connect_timeout_only(session, request):
+def test_connect_timeout_only(session_mock, request_mock):
     misc_options = dict(connect_timeout=1)
-    future = RequestsFutureAdapter(session, request, misc_options)
+    future = RequestsFutureAdapter(session_mock, request_mock, misc_options)
     assert future.build_timeout(result_timeout=None) == (1, None)

--- a/tests/requests_client/RequestsFutureAdapter/conftest.py
+++ b/tests/requests_client/RequestsFutureAdapter/conftest.py
@@ -5,10 +5,10 @@ from requests.sessions import Session
 
 
 @pytest.fixture
-def request():
+def request_mock():
     return Mock(url='http://foo.com')
 
 
 @pytest.fixture
-def session():
+def session_mock():
     return Mock(spec=Session)

--- a/tests/requests_client/RequestsFutureAdapter/header_type_casting_test.py
+++ b/tests/requests_client/RequestsFutureAdapter/header_type_casting_test.py
@@ -2,12 +2,12 @@
 from bravado.requests_client import RequestsFutureAdapter
 
 
-def test_result_header_values_are_bytes(session, request):
-    session.merge_environment_settings.return_value = {}
-    request.headers = {b'X-Foo': b'hi'}
-    RequestsFutureAdapter(session, request, misc_options={'ssl_verify': True, 'ssl_cert': None}).result()
+def test_result_header_values_are_bytes(session_mock, request_mock):
+    session_mock.merge_environment_settings.return_value = {}
+    request_mock.headers = {b'X-Foo': b'hi'}
+    RequestsFutureAdapter(session_mock, request_mock, misc_options={'ssl_verify': True, 'ssl_cert': None}).result()
 
     # prepare_request should be called with a request containing correctly
     # casted headers (bytestrings should be preserved)
-    prepared_headers = session.prepare_request.call_args[0][0].headers
+    prepared_headers = session_mock.prepare_request.call_args[0][0].headers
     assert prepared_headers == {b'X-Foo': b'hi'}


### PR DESCRIPTION
Rename the `request` and `session` fixtures to prevent the `PytestDeprecationWarning`, otherwise the `'request' is a reserved name for fixtures and will raise an error in future versions` deprecation warning failed builds for python 3 envs.