### PR TITLE
Require pytest < 5.1.0 to fix the build on Python 3.5.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ httpretty
 mock
 pip>=9.0.1 # workaround to https://github.com/pypa/pip/issues/3903
 pre-commit
-pytest
+pytest<5.1  # fix typing issue with pytest on Python 3.5.0
 u-msgpack-python


### PR DESCRIPTION
I'm not 100% sure if this was the version that introduced the issue. Let's get a travis run to confirm.

Traceback from our build:

```python
Traceback (most recent call last):
  File "/opt/python/3.5.0/lib/python3.5/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/python/3.5.0/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/travis/build/Yelp/bravado/.tox/py35-default/lib/python3.5/site-packages/pytest.py", line 6, in <module>
    from _pytest.assertion import register_assert_rewrite
  File "/home/travis/build/Yelp/bravado/.tox/py35-default/lib/python3.5/site-packages/_pytest/assertion/__init__.py", line 6, in <module>
    from _pytest.assertion import rewrite
  File "/home/travis/build/Yelp/bravado/.tox/py35-default/lib/python3.5/site-packages/_pytest/assertion/rewrite.py", line 24, in <module>
    from _pytest.assertion import util
  File "/home/travis/build/Yelp/bravado/.tox/py35-default/lib/python3.5/site-packages/_pytest/assertion/util.py", line 5, in <module>
    import _pytest._code
  File "/home/travis/build/Yelp/bravado/.tox/py35-default/lib/python3.5/site-packages/_pytest/_code/__init__.py", line 2, in <module>
    from .code import Code  # noqa
  File "/home/travis/build/Yelp/bravado/.tox/py35-default/lib/python3.5/site-packages/_pytest/_code/code.py", line 388, in <module>
    class ExceptionInfo(Generic[_E]):
  File "/home/travis/build/Yelp/bravado/.tox/py35-default/lib/python3.5/site-packages/_pytest/_code/code.py", line 594, in ExceptionInfo
    def match(self, regexp: Union[str, Pattern]) -> bool:
  File "/opt/python/3.5.0/lib/python3.5/typing.py", line 534, in __getitem__
    dict(self.__dict__), parameters, _root=True)
  File "/opt/python/3.5.0/lib/python3.5/typing.py", line 491, in __new__
    for t2 in all_params - {t1} if not isinstance(t2, TypeVar)):
  File "/opt/python/3.5.0/lib/python3.5/typing.py", line 491, in <genexpr>
    for t2 in all_params - {t1} if not isinstance(t2, TypeVar)):
TypeError: issubclass() arg 1 must be a class
```

This issue is tracked upstream as pytest-dev/pytest#5751.