### PR TITLE
Allow custom future and response adapter classes in clients

### DIFF
--- a/CHANGELOG-MASTER.rst
+++ b/CHANGELOG-MASTER.rst
@@ -3,4 +3,5 @@ Changelog-Master
 
 .. _PR32: https://github.com/Yelp/bravado/pull/32
 
-Show the response text when an unexpected 5xx response is returned. This fixes the regression for PR32_.
+- Show the response text when an unexpected 5xx response is returned. This fixes the regression for PR32_.
+- Allow custom future and response adapter classes in both ``RequestsClient`` and ``FidoClient``.

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -97,6 +97,21 @@ class FidoClient(HttpClient):
     """Fido (Asynchronous) HTTP client implementation.
     """
 
+    def __init__(
+        self,
+        future_adapter_class=None,  # type: typing.Optional[typing.Type[FidoFutureAdapter]]
+        response_adapter_class=None,  # type: typing.Optional[FidoResponseAdapter]
+    ):
+        # type: (...) -> None
+        """
+        :param future_adapter_class: Custom future adapter class,
+            should be a subclass of :class:`FidoFutureAdapter`
+        :param response_adapter_class: Custom response adapter class,
+            should be a subclass of :class:`FidoResponseAdapter`
+        """
+        self.future_adapter_class = future_adapter_class or FidoFutureAdapter
+        self.response_adapter_class = response_adapter_class or FidoResponseAdapter
+
     def request(
         self,
         request_params,  # type: typing.MutableMapping[str, typing.Any]

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -100,7 +100,7 @@ class FidoClient(HttpClient):
     def __init__(
         self,
         future_adapter_class=None,  # type: typing.Optional[typing.Type[FidoFutureAdapter]]
-        response_adapter_class=None,  # type: typing.Optional[FidoResponseAdapter]
+        response_adapter_class=None,  # type: typing.Optional[typing.Type[FidoResponseAdapter]]
     ):
         # type: (...) -> None
         """

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -127,7 +127,7 @@ class RequestsClient(HttpClient):
         ssl_verify=True,  # type: bool
         ssl_cert=None,  # type:  typing.Any
         future_adapter_class=None,  # type: typing.Optional[typing.Type[RequestsFutureAdapter]]
-        response_adapter_class=None,  # type: typing.Optional[RequestsResponseAdapter]
+        response_adapter_class=None,  # type: typing.Optional[typing.Type[RequestsResponseAdapter]]
     ):
         # type: (...) -> None
         """

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -122,19 +122,31 @@ class RequestsClient(HttpClient):
     """Synchronous HTTP client implementation.
     """
 
-    def __init__(self, ssl_verify=True, ssl_cert=None):
-        # type: (bool, typing.Any) -> None
+    def __init__(
+        self,
+        ssl_verify=True,  # type: bool
+        ssl_cert=None,  # type:  typing.Any
+        future_adapter_class=None,  # type: typing.Optional[typing.Type[RequestsFutureAdapter]]
+        response_adapter_class=None,  # type: typing.Optional[RequestsResponseAdapter]
+    ):
+        # type: (...) -> None
         """
         :param ssl_verify: Set to False to disable SSL certificate validation. Provide the path to a
             CA bundle if you need to use a custom one.
         :param ssl_cert: Provide a client-side certificate to use. Either a sequence of strings pointing
             to the certificate (1) and the private key (2), or a string pointing to the combined certificate
             and key.
+        :param future_adapter_class: Custom future adapter class,
+            should be a subclass of :class:`RequestsFutureAdapter`
+        :param response_adapter_class: Custom response adapter class,
+            should be a subclass of :class:`RequestsResponseAdapter`
         """
         self.session = requests.Session()
         self.authenticator = None  # type: typing.Optional[Authenticator]
         self.ssl_verify = ssl_verify
         self.ssl_cert = ssl_cert
+        self.future_adapter_class = future_adapter_class or RequestsFutureAdapter
+        self.response_adapter_class = response_adapter_class or RequestsResponseAdapter
 
     def separate_params(
         self,
@@ -188,7 +200,7 @@ class RequestsClient(HttpClient):
         """
         sanitized_params, misc_options = self.separate_params(request_params)
 
-        requests_future = RequestsFutureAdapter(
+        requests_future = self.future_adapter_class(
             self.session,
             self.authenticated_request(sanitized_params),
             misc_options,
@@ -196,7 +208,7 @@ class RequestsClient(HttpClient):
 
         return HttpFuture(
             requests_future,
-            RequestsResponseAdapter,
+            self.response_adapter_class,
             operation,
             request_config,
         )

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -85,11 +85,17 @@ to the ``verify`` and ``cert`` options of the requests library; please check
 `their documentation <http://www.python-requests.org/en/master/user/advanced/#ssl-cert-verification>`_ for usage
 instructions. Note that bravado honors the ``REQUESTS_CA_BUNDLE`` environment variable as well.
 
+Also you can specify custom future adapter and response adapter classes through the ``future_adapter_class`` and
+``response_adapter_class`` arguments respectively.
+
 Using a different HTTP client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use other HTTP clients with bravado; the fido client ships with bravado (:class:`bravado.fido_client.FidoClient`).
 Currently the fido client doesn't support customizing SSL/TLS behavior.
+But the future adapter and response adapter classes could be specified in the same manner as for
+:class:`bravado.requests_client.RequestsClient` - through the ``future_adapter_class`` and
+``response_adapter_class`` arguments respectively.
 
 Another well-supported option is `bravado_asyncio <https://github.com/sjaensch/bravado-asyncio>`_, which requires
 Python 3.5+. It supports the same ssl options as the default requests client.

--- a/tests/integration/requests_client_test.py
+++ b/tests/integration/requests_client_test.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import mock
 import pytest
 import requests.exceptions
 import typing
@@ -35,9 +34,9 @@ class FakeRequestsFutureAdapter(RequestsFutureAdapter):
 
 
 class FakeRequestsClient(RequestsClient):
-    @mock.patch('bravado.requests_client.RequestsFutureAdapter', FakeRequestsFutureAdapter)
-    def request(self, *args, **kwargs):
-        return super(FakeRequestsClient, self).request(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        kwargs['future_adapter_class'] = FakeRequestsFutureAdapter
+        super(FakeRequestsClient, self).__init__(*args, **kwargs)
 
 
 class TestServerRequestsClientFake(IntegrationTestsBaseClass):


### PR DESCRIPTION
Allow custom future and response adapter classes in both `RequestsClient` and `FidoClient` through `future_adapter_class` and `response_adapter_class` params respectively.

This PR is opened to replace the #426, in which these adapter classes were proposed as class-level attributes.