### PR TITLE
Fix mypy issue related to types in HTTPErrorType

### DIFF
--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -37,12 +37,16 @@ def _register_exception(exception_class):
     status_map[exception_class.status_code] = exception_class
 
 
+if getattr(typing, 'TYPE_CHECKING', False):
+    T2 = typing.TypeVar('T2', bound=type)
+
+
 class HTTPErrorType(type):
     """A metaclass for registering HTTPError subclasses."""
 
     def __new__(cls, *args, **kwargs):
-        # type: (typing.Type[type], typing.Any, typing.Any) -> type
-        new_class = super(HTTPErrorType, cls).__new__(cls, *args, **kwargs)
+        # type: (typing.Type[T2], typing.Any, typing.Any) -> T2
+        new_class = typing.cast('T2', type.__new__(cls, *args, **kwargs))
         if hasattr(new_class, 'status_code'):
             _register_exception(new_class)
         return new_class


### PR DESCRIPTION
The build started failing due to mypy 0.730 complaining about two issues related to the `__new__` method:

```
bravado/exception.py:43: error: Incompatible return type for "__new__" (returns "type", but must return a subtype of "HTTPErrorType")
bravado/exception.py:45: error: Too many arguments for "__new__" of "object"
```

The first issue seems to be legitimate, the type annotation is not fully correct. The second issue seems to be more due to mypy's understanding of what `super` does in this case. It thinks it returns `object.__new__`, when in fact it is `type.__new__`. I've made that explicit.

Unfortunately the type annotation of `type.__new__` is wrong - it says it returns an instance of `type`, when in fact it returns an instance of `cls`, which will be a subtype of `type`.