### PR TITLE
Fix build; loosen type annotation for response adapter argument 

### DIFF
--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -146,7 +146,7 @@ class HttpFuture(typing.Generic[T]):
     def __init__(
         self,
         future,  # type: FutureAdapter
-        response_adapter,  # type: typing.Type[IncomingResponse]
+        response_adapter,  # type: typing.Callable[[typing.Any], IncomingResponse]
         operation=None,  # type: typing.Optional[Operation]
         request_config=None,  # type: typing.Optional[RequestConfig]
     ):

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -271,6 +271,7 @@ class HttpFuture(typing.Generic[T]):
         swagger_result = self._get_swagger_result(incoming_response)
 
         if self.operation is not None:
+            swagger_result = typing.cast(T, swagger_result)
             if self.request_config.also_return_response:
                 return swagger_result, incoming_response
             return swagger_result
@@ -331,7 +332,7 @@ def unmarshal_response(
 
     try:
         raise_on_unexpected(incoming_response)
-        incoming_response.swagger_result = unmarshal_response_inner(
+        incoming_response.swagger_result = unmarshal_response_inner(  # type: ignore
             response=incoming_response,
             op=operation,
         )

--- a/bravado/response.py
+++ b/bravado/response.py
@@ -49,7 +49,7 @@ class BravadoResponseMetadata(typing.Generic[T]):
 
     def __init__(
         self,
-        incoming_response,  # type: IncomingResponse
+        incoming_response,  # type: typing.Optional[IncomingResponse]
         swagger_result,  # type: typing.Optional[T]
         start_time,  # type: float
         request_end_time,  # type: float

--- a/bravado/testing/integration_test.py
+++ b/bravado/testing/integration_test.py
@@ -415,8 +415,8 @@ class IntegrationTestsBaseClass(IntegrationTestingFixturesMixin):
 
         http_future_1 = self.http_client.request(request_one_params)
         http_future_2 = self.http_client.request(request_two_params)
-        resp_one = http_future_1.result(timeout=1)  # type: IncomingResponse
-        resp_two = http_future_2.result(timeout=1)  # type: IncomingResponse
+        resp_one = typing.cast(IncomingResponse, http_future_1.result(timeout=1))
+        resp_two = typing.cast(IncomingResponse, http_future_2.result(timeout=1))
 
         assert resp_one.text == self.encode_expected_response(ROUTE_1_RESPONSE)
         assert resp_two.text == self.encode_expected_response(ROUTE_2_RESPONSE)
@@ -431,7 +431,7 @@ class IntegrationTestsBaseClass(IntegrationTestingFixturesMixin):
         }
 
         http_future = self.http_client.request(request_args)
-        resp = http_future.result(timeout=1)  # type: IncomingResponse
+        resp = typing.cast(IncomingResponse, http_future.result(timeout=1))
 
         assert resp.text == self.encode_expected_response(b'6')
 
@@ -441,12 +441,12 @@ class IntegrationTestsBaseClass(IntegrationTestingFixturesMixin):
             'Header-Integer': 1,
             'Header-Bytes': b'0',
         }
-        response = self.http_client.request({
+        response = typing.cast(IncomingResponse, self.http_client.request({
             'method': 'GET',
             'headers': headers,
             'url': '{server_address}/headers'.format(server_address=swagger_http_server),
             'params': {},
-        }).result(timeout=1)  # type: IncomingResponse
+        }).result(timeout=1))
 
         expected_header_representations = {
             'Header-Boolean': repr('True'),
@@ -462,14 +462,14 @@ class IntegrationTestsBaseClass(IntegrationTestingFixturesMixin):
         } == response.json()
 
     def test_msgpack_support(self, swagger_http_server):
-        response = self.http_client.request({
+        response = typing.cast(IncomingResponse, self.http_client.request({
             'method': 'GET',
             'url': '{server_address}/json_or_msgpack'.format(server_address=swagger_http_server),
             'params': {},
             'headers': {
                 'Accept': APP_MSGPACK,
             },
-        }).result(timeout=1)  # type: IncomingResponse
+        }).result(timeout=1))
 
         assert response.headers['Content-Type'] == APP_MSGPACK
         assert unpackb(response.raw_bytes, encoding='utf-8') == API_RESPONSE

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -6,6 +6,7 @@ import httpretty
 import mock
 import pytest
 import requests
+import typing
 from bravado_core.response import IncomingResponse
 
 from bravado.requests_client import RequestsClient
@@ -30,7 +31,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params = self._default_params()
         params['params'] = {'foo': 'bar'}
 
-        resp = client.request(params).result()  # type: IncomingResponse
+        resp = typing.cast(IncomingResponse, client.request(params).result())
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -47,7 +48,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params = self._default_params()
         params['params'] = {'foo': u'酒場'}
 
-        resp = client.request(params).result()  # type: IncomingResponse
+        resp = typing.cast(IncomingResponse, client.request(params).result())
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -65,7 +66,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params['data'] = {'foo': 'bar'}
         params['method'] = 'POST'
 
-        resp = client.request(params).result()  # type: IncomingResponse
+        resp = typing.cast(IncomingResponse, client.request(params).result())
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -86,7 +87,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params = self._default_params()
         params['params'] = {'foo': 'bar'}
 
-        resp = client.request(params).result()  # type: IncomingResponse
+        resp = typing.cast(IncomingResponse, client.request(params).result())
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -107,7 +108,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params = self._default_params()
         params['params'] = {'foo': 'bar'}
 
-        resp = client.request(params).result()  # type: IncomingResponse
+        resp = typing.cast(IncomingResponse, client.request(params).result())
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -127,7 +128,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params = self._default_params()
         params['params'] = {'foo': 'bar'}
 
-        resp = client.request(params).result()  # type: IncomingResponse
+        resp = typing.cast(IncomingResponse, client.request(params).result())
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -148,7 +149,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params['params'] = {'foo': 'bar'}
         params['headers'] = {'Key': 'def456'}
 
-        resp = client.request(params).result()  # type: IncomingResponse
+        resp = typing.cast(IncomingResponse, client.request(params).result())
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)
@@ -168,7 +169,7 @@ class RequestsClientTestCase(unittest.TestCase):
         params['params'] = {'foo': 'bar'}
         params['url'] = 'http://hackerz.py'
 
-        resp = client.request(params).result()  # type: IncomingResponse
+        resp = typing.cast(IncomingResponse, client.request(params).result())
 
         self.assertEqual(200, resp.status_code)
         self.assertEqual('expected', resp.text)

--- a/tests/http_future/HttpFuture/cancel_test.py
+++ b/tests/http_future/HttpFuture/cancel_test.py
@@ -21,7 +21,7 @@ def test_cancel():
     mock_future_adapter = mock.Mock()
     future = HttpFuture(
         future=mock_future_adapter,
-        response_adapter=IncomingResponse(),
+        response_adapter=lambda x: IncomingResponse(),
     )  # type: HttpFuture[None]
     future.cancel()
 
@@ -32,7 +32,7 @@ def test_cancel_is_backwards_compatible(mock_log):
     future_adapter = MyFutureAdapter()
     future = HttpFuture(
         future=future_adapter,
-        response_adapter=IncomingResponse(),
+        response_adapter=lambda x: IncomingResponse(),
     )  # type: HttpFuture[None]
     future.cancel()
 


### PR DESCRIPTION
The type annotation for the `response_adapter` is too strict - it doesn't have to be a subclass of `IncomingResponse`, it can be anything that, when called with the raw response as argument, will return a subclass of `IncomingResponse`. `bravado-asyncio` handles this a bit different from how it's handled within the HTTP clients shipped as part of bravado since it needs to pass in the current event loop to the response adapter as well.

This type annotation has the same expressiveness while being loose enough so that the new mypy version doesn't complain anymore when run on the bravado-asyncio codebase ([example of failure](https://travis-ci.org/sjaensch/bravado-asyncio/jobs/602558095?utm_medium=notification&utm_source=email)).

In the second commit I'm fixing all of the mypy issues that are cropping up with the new version. These are happening on master too.