### PR TITLE
Run pre-commit autoupdate to properly update and pin revisions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v1.2.0
+    rev: v2.4.0
     hooks:
     -   id: check-json
     -   id: check-yaml
@@ -12,21 +12,21 @@ repos:
     -   id: requirements-txt-fixer
         files: requirements-dev.txt
 -   repo: git://github.com/pre-commit/mirrors-autopep8
-    rev: v1.4.3
+    rev: v1.4.4
     hooks:
     -   id: autopep8
         args: ['-i', '--ignore=E309,E501']
 -   repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.7.6
+    rev: 3.7.9
     hooks:
     -   id: flake8
         exclude: ^docs
 -   repo: git://github.com/asottile/reorder_python_imports
-    sha: v1.0.1
+    rev: v1.8.0
     hooks:
     -   id: reorder-python-imports
 -   repo: git://github.com/Yelp/detect-secrets
-    sha: 0.9.1
+    rev: v0.13.0
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,6 +1,9 @@
 {
-  "exclude_regex": "tests/.*",
-  "generated_at": "2018-07-12T23:39:58Z",
+  "exclude": {
+    "files": "tests/.*",
+    "lines": null
+  },
+  "generated_at": "2019-11-04T12:54:21Z",
   "plugins_used": [
     {
       "base64_limit": 4.5,
@@ -15,5 +18,9 @@
     }
   ],
   "results": {},
-  "version": "0.9.1"
+  "version": "0.13.0",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
 }

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -3,9 +3,7 @@ import logging
 import sys
 
 import crochet
-import fido
 import fido.exceptions
-import requests
 import requests.structures
 import six
 import twisted.internet.error

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -2,7 +2,6 @@
 import copy
 import logging
 
-import requests
 import requests.auth
 import requests.exceptions
 import six

--- a/bravado/swagger_model.py
+++ b/bravado/swagger_model.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import contextlib
 import logging
-import os
 import os.path
 
 import typing

--- a/bravado/testing/integration_test.py
+++ b/bravado/testing/integration_test.py
@@ -6,7 +6,6 @@ from multiprocessing import Process
 import bottle
 import ephemeral_port_reserve
 import pytest
-import requests
 import requests.exceptions
 import typing
 from bravado_core.content_type import APP_MSGPACK


### PR DESCRIPTION
pre-commit was issuing warnings about an unknown key `sha` - which means those repositories were not properly pinned as intended. I ran `pre-commit autoupdate`, which fixed the issue and bumped all versions. I then reran pre-commit hooks on all files, which explains the changes to the other files.