### PR TITLE
Change type of http client requestparams from MutableMapping to Mapping

### DIFF
--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -154,7 +154,7 @@ class FidoClient(HttpClient):
 
     def request(
         self,
-        request_params,  # type: typing.MutableMapping[str, typing.Any]
+        request_params,  # type: typing.Mapping[str, typing.Any]
         operation=None,  # type: typing.Optional[Operation]
         request_config=None,  # type: typing.Optional[RequestConfig]
     ):
@@ -184,7 +184,7 @@ class FidoClient(HttpClient):
 
     @staticmethod
     def prepare_request_for_twisted(request_params):
-        # type: (typing.MutableMapping[str, typing.Any]) -> typing.Mapping[str, typing.Any]
+        # type: (typing.Mapping[str, typing.Any]) -> typing.Mapping[str, typing.Any]
         """
         Uses the python package 'requests' to prepare the data as per twisted
         needs. requests.PreparedRequest.prepare is able to compute the body and
@@ -207,13 +207,13 @@ class FidoClient(HttpClient):
 
         # Ensure that all the headers are converted to strings.
         # This is need to workaround https://github.com/requests/requests/issues/3491
-        request_params['headers'] = {
+        string_headers = {
             k: v if isinstance(v, six.binary_type) else str(v)
             for k, v in six.iteritems(request_params.get('headers', {}))
         }
 
         prepared_request.prepare(
-            headers=request_params.get('headers'),
+            headers=string_headers,
             data=request_params.get('data'),
             params=request_params.get('params'),
             files=request_params.get('files'),

--- a/bravado/http_client.py
+++ b/bravado/http_client.py
@@ -16,7 +16,7 @@ class HttpClient(object):
 
     def request(
         self,
-        request_params,  # type: typing.MutableMapping[str, typing.Any]
+        request_params,  # type: typing.Mapping[str, typing.Any]
         operation=None,  # type: typing.Optional[Operation]
         request_config=None,  # type: typing.Optional[RequestConfig]
     ):

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import copy
 import logging
 
 import requests

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -307,7 +307,7 @@ class RequestsClient(HttpClient):
 
     def separate_params(
         self,
-        request_params,  # type: typing.MutableMapping[str, typing.Any]
+        request_params,  # type: typing.Mapping[str, typing.Any]
     ):
         # type: (...) -> typing.Tuple[typing.Mapping[str, typing.Any], typing.Mapping[str, typing.Any]]
         """Splits the passed in dict of request_params into two buckets.
@@ -321,7 +321,7 @@ class RequestsClient(HttpClient):
             read-only dict.
         :returns: tuple(sanitized_params, misc_options)
         """
-        sanitized_params = copy.copy(request_params)
+        sanitized_params = dict(request_params)
         misc_options = {
             'ssl_verify': self.ssl_verify,
             'ssl_cert': self.ssl_cert,
@@ -338,7 +338,7 @@ class RequestsClient(HttpClient):
 
     def request(
         self,
-        request_params,  # type: typing.MutableMapping[str, typing.Any]
+        request_params,  # type: typing.Mapping[str, typing.Any]
         operation=None,  # type: typing.Optional[Operation]
         request_config=None,  # type: typing.Optional[RequestConfig]
     ):


### PR DESCRIPTION
Request params should not be modified by the http client, as this can lead to unexpected bugs if the caller passes the same parameter dict to multiple requests.