### PR TITLE
Remove modindex from docs, configure RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: requirements-docs.txt

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,4 +41,3 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+sphinx
+sphinx-rtd-theme
+.[fido]
+.[integration-tests]

--- a/tox.ini
+++ b/tox.ini
@@ -41,10 +41,7 @@ commands =
 
 [testenv:docs]
 deps =
-    sphinx
-    sphinx-rtd-theme
-    .[fido]
-    .[integration-tests]
+    -rrequirements-docs.txt
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html
 


### PR DESCRIPTION
Looks like it's not generated properly anymore on readthedocs. It's not really a problem since we have basically [the same thing](https://bravado.readthedocs.io/en/latest/modules.html) as part of our documentation, but with a better title.

Fixes #285 