### PR TITLE
Reraise fido HttpTimeoutError without modification

### DIFF
--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -112,10 +112,23 @@ class FidoFutureAdapter(FutureAdapter[T]):
 
     def result(self, timeout=None):
         # type: (typing.Optional[float]) -> T
+
+        # Note: There are two kinds of timeouts that can occur here.
+        #
+        # 1. Fido request fails with a `fido.exceptions.HttpTimeoutError` due
+        # to the configured request timeout. In this case we don't want to
+        # modify the original exception.
+        #
+        # 2. The `EventualResult` is not completed within the specified wait
+        # timeout. In this case we cancel the request and transform the
+        # `crochet.TimeoutError` into a `fido.exceptions.HttpTimeoutError`.
         try:
             return self._eventual_result.wait(timeout=timeout)
         except fido.exceptions.HTTPTimeoutError:
-            raise  # Don't modify original exception
+            # Since `fido.exceptions.HttpTimeoutError` is a subclass of
+            # `crochet.TimeoutError` we catch and re-throw the exception to
+            # exclude it from the `except` block below.
+            raise
         except crochet.TimeoutError:
             self.cancel()
             six.reraise(

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -114,6 +114,8 @@ class FidoFutureAdapter(FutureAdapter[T]):
         # type: (typing.Optional[float]) -> T
         try:
             return self._eventual_result.wait(timeout=timeout)
+        except fido.exceptions.HTTPTimeoutError:
+            raise  # Don't modify original exception
         except crochet.TimeoutError:
             self.cancel()
             six.reraise(

--- a/bravado/testing/integration_test.py
+++ b/bravado/testing/integration_test.py
@@ -484,6 +484,18 @@ class IntegrationTestsBaseClass(IntegrationTestingFixturesMixin):
                 'params': {},
             }).result(timeout=0.01)
 
+    def test_request_timeout_errors_are_thrown_as_BravadoTimeoutError(self, swagger_http_server):
+        if not self.http_future_adapter_type.timeout_errors:
+            pytest.skip('{} does NOT defines timeout_errors'.format(self.http_future_adapter_type))
+
+        with pytest.raises(BravadoTimeoutError):
+            self.http_client.request({
+                'method': 'GET',
+                'url': '{server_address}/sleep?sec=0.1'.format(server_address=swagger_http_server),
+                'params': {},
+                'timeout': 0.01,
+            }).result()
+
     def test_swagger_client_timeout_errors_are_thrown_as_BravadoTimeoutError(
         self, swagger_client, result_getter,
     ):


### PR DESCRIPTION
Currently if fido raises a `fido.exceptions.HttpTimeoutError` while performing a request, the original error message will be replaced by the code in `FidoFutureAdapter`.  This can lead to the wrong timeout value being reported in the error message.

There are two cases that can happen.

1. Crochet `EventualResult` does not receive a result within the specified wait timeout, throws a `crochet.TimeoutError`.  In this case the future adapter should wrap the exception with `fido.exceptions.HttpTimeoutError`.  This is the existing functionality.

2. Request fails with `fido.exceptions.HttpTimeoutError`.  In this case the future adapter should reraise the original exception.  Since `fido.exceptions.HttpTimeoutError` is a subclass of `crochet.TimeoutError` we need to explicitly exclude this from case 1.