### PR TITLE
Fix path to sphinx config in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@
 version: 2
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
Recent RTD doc builds are broken, looks like since the merge of #442, e.g. https://readthedocs.org/projects/bravado/builds/10293384/

I suspect it's because of this path mistake, but it looks like RTD's config thingie doesn't actually check that the path is valid? Strange.