### PR TITLE
update `unmarshal_response` to handle `use_models=False` better

### DIFF
--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -366,21 +366,31 @@ def unmarshal_response_inner(
     :returns: value where type(value) matches response_spec['schema']['type']
         if it exists, None otherwise.
     """
-    deref = op.swagger_spec.deref
-    response_spec = get_response_spec(status_code=response.status_code, op=op)
-
-    if 'schema' not in response_spec:
-        return None
 
     content_type = response.headers.get('content-type', '').lower()
-
     if content_type.startswith(APP_JSON) or content_type.startswith(APP_MSGPACK):
-        content_spec = deref(response_spec['schema'])
+        use_models = op.swagger_spec.config.get('use_models', True)
         if content_type.startswith(APP_JSON):
             content_value = response.json()
         else:
             content_value = unpackb(response.raw_bytes, encoding='utf-8')
 
+        try:
+            response_spec = get_response_spec(
+                status_code=response.status_code, op=op)
+        except MatchingResponseNotFound:
+            if not use_models:
+                return content_value
+
+            six.reraise(*sys.exc_info())
+
+        if 'schema' not in response_spec:
+            if not use_models:
+                return content_value
+
+            return None
+
+        content_spec = op.swagger_spec.deref(response_spec['schema'])
         if op.swagger_spec.config.get('validate_responses', False):
             validate_schema_object(op.swagger_spec, content_spec, content_value)
 

--- a/tests/functional/spec_func_test.py
+++ b/tests/functional/spec_func_test.py
@@ -51,7 +51,7 @@ def test_headers_sendable_with_api_doc_request(httprettified, swagger_dict):
 
 
 def test_hostname_if_passed_overrides_origin_url(httprettified, swagger_dict):
-    register_get("http://foo/test_http?", body='')
+    register_get("http://foo/test_http?", body='{}')
     swagger_dict['host'] = 'foo'
     register_spec(swagger_dict)
     resource = SwaggerClient.from_url(API_DOCS_URL).api_test

--- a/tests/http_future/unmarshall_response_inner_test.py
+++ b/tests/http_future/unmarshall_response_inner_test.py
@@ -4,6 +4,7 @@ import msgpack
 import pytest
 from bravado_core.content_type import APP_JSON
 from bravado_core.content_type import APP_MSGPACK
+from bravado_core.exception import MatchingResponseNotFound
 from bravado_core.response import IncomingResponse
 from bravado_core.spec import Spec
 
@@ -37,16 +38,18 @@ def mock_validate_schema_object():
         yield m
 
 
-def test_no_content(mock_get_response_spec, empty_swagger_spec):
-    response_spec = {
-        'description': "I don't have a 'schema' key so I return nothing",
-    }
-    response = mock.Mock(spec=IncomingResponse, status_code=200)
+def test_no_content(mock_get_response_spec, empty_swagger_spec, response_spec):
+    response = mock.Mock(
+        spec=IncomingResponse,
+        status_code=200,
+        headers={},
+        text='',
+    )
 
     mock_get_response_spec.return_value = response_spec
     op = mock.Mock(swagger_spec=empty_swagger_spec)
     result = unmarshal_response_inner(response, op)
-    assert result is None
+    assert result == ''
 
 
 def test_json_content(mock_get_response_spec, empty_swagger_spec, response_spec):
@@ -60,6 +63,47 @@ def test_json_content(mock_get_response_spec, empty_swagger_spec, response_spec)
     mock_get_response_spec.return_value = response_spec
     op = mock.Mock(swagger_spec=empty_swagger_spec)
     assert 'Monday' == unmarshal_response_inner(response, op)
+
+
+@pytest.mark.parametrize('use_models', [True, False])
+def test_json_content_no_schema(mock_get_response_spec, empty_swagger_spec, use_models):
+    empty_swagger_spec.config['use_models'] = use_models
+    response_spec = {
+        'description': "I don't have a 'schema' key so I return nothing",
+    }
+    response = mock.Mock(
+        spec=IncomingResponse,
+        status_code=200,
+        headers={'content-type': APP_JSON},
+        json=mock.Mock(return_value='Monday'),
+    )
+
+    mock_get_response_spec.return_value = response_spec
+    op = mock.Mock(swagger_spec=empty_swagger_spec)
+    result = unmarshal_response_inner(response, op)
+    if use_models:
+        assert result is None
+    else:
+        assert result == 'Monday'
+
+
+@pytest.mark.parametrize('use_models', [True, False])
+def test_json_content_no_matching_schema(mock_get_response_spec, empty_swagger_spec, response_spec, use_models):
+    empty_swagger_spec.config['use_models'] = use_models
+    response = mock.Mock(
+        spec=IncomingResponse,
+        status_code=200,
+        headers={'content-type': APP_JSON},
+        json=mock.Mock(return_value='Monday'),
+    )
+
+    mock_get_response_spec.side_effect = MatchingResponseNotFound
+    op = mock.Mock(swagger_spec=empty_swagger_spec)
+    if use_models:
+        with pytest.raises(MatchingResponseNotFound):
+            unmarshal_response_inner(response, op)
+    else:
+        assert 'Monday' == unmarshal_response_inner(response, op)
 
 
 def test_msgpack_content(mock_get_response_spec, empty_swagger_spec, response_spec):


### PR DESCRIPTION
I believe this is the correct behavior, but it looks like there might be more things that should probably respect `use_models` based on my testing of this with a package which has a bit incomplete schema.