### PR TITLE
Rename option from allow_redirect to follow_redirects, add documentation

### DIFF
--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -226,7 +226,7 @@ class FidoClient(HttpClient):
                 'url': string,
                 'timeout': float,  # optional
                 'connect_timeout': float,  # optional
-                'allow_redirects': bool,  # optional
+                'follow_redirects': bool,  # optional
             }
         """
 

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -226,7 +226,6 @@ class FidoClient(HttpClient):
                 'url': string,
                 'timeout': float,  # optional
                 'connect_timeout': float,  # optional
-                'follow_redirects': bool,  # optional
             }
         """
 

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -266,7 +266,7 @@ class RequestsFutureAdapter(FutureAdapter):
         response = self.session.send(
             prepared_request,
             timeout=self.build_timeout(timeout),
-            allow_redirects=self.misc_options['allow_redirects'],
+            follow_redirects=self.misc_options['follow_redirects'],
             **settings
         )
         return response
@@ -361,7 +361,7 @@ class RequestsClient(HttpClient):
         misc_options = {
             'ssl_verify': self.ssl_verify,
             'ssl_cert': self.ssl_cert,
-            'allow_redirects': sanitized_params.pop('allow_redirects', False),
+            'follow_redirects': sanitized_params.pop('follow_redirects', False),
         }
 
         if 'connect_timeout' in sanitized_params:

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -266,7 +266,7 @@ class RequestsFutureAdapter(FutureAdapter):
         response = self.session.send(
             prepared_request,
             timeout=self.build_timeout(timeout),
-            follow_redirects=self.misc_options['follow_redirects'],
+            allow_redirects=self.misc_options['follow_redirects'],
             **settings
         )
         return response

--- a/bravado/testing/integration_test.py
+++ b/bravado/testing/integration_test.py
@@ -512,7 +512,7 @@ class IntegrationTestsBaseClass(IntegrationTestingFixturesMixin):
             'method': 'GET',
             'url': '{server_address}/redirect'.format(server_address=swagger_http_server),
             'params': {},
-            'allow_redirects': True,
+            'follow_redirects': True,
         }).result(timeout=1)
 
         assert isinstance(response, IncomingResponse) and response.status_code == 200

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -149,7 +149,6 @@ Config key                Type      Default  Description
 *follow_redirects*        boolean   False    | Whether redirects returned by the server
                                              | are followed, or returned as-is.
                                              | **Note:** Currently, the fido HTTP client
-                                             | does not support returning redirect
-                                             | responses directly, and will always follow
-                                             | redirects.
+                                             | does not support following redirects, and
+                                             | will ignore this option.
 ========================= ========= =======  ===============================================

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -113,26 +113,43 @@ Configuration can also be applied on a per-request basis by passing in
     request_options = { ... }
     client.pet.getPetById(petId=42, _request_options=request_options).response().result
 
-========================= =============== =========  ===============================================================
-Config key                Type            Default    Description
-------------------------- --------------- ---------  ---------------------------------------------------------------
-*connect_timeout*         float           N/A        | TCP connect timeout in seconds. This is passed along to the
-                                                     | http_client when making a service call.
-*headers*                 dict            N/A        | Dict of http headers to to send with the outgoing request.
-*response_callbacks*      list of         []         | List of callables that are invoked after the incoming
-                          callables                  | response has been validated and unmarshalled but before being
-                                                     | returned to the calling client. This is useful for client
-                                                     | decorators that would like to hook into the post-receive
-                                                     | event. The callables are executed in the order they appear
-                                                     | in the list.
-                                                     | Two parameters are passed to each callable:
-                                                     | - ``incoming_response`` of type ``bravado_core.response.IncomingResponse``
-                                                     | - ``operation`` of type ``bravado_core.operation.Operation``
-*timeout*                 float           N/A        | TCP idle timeout in seconds. This is passed along to the
-                                                     | http_client when making a service call.
-*use_msgpack*             boolean         False      | If a msgpack serialization is desired for the response. This
-                                                     | will add a Accept: application/msgpack header to the request.
-*force_fallback_result*   boolean         False      | Whether a potentially provided fallback result should always
-                                                     | be returned, regardless of whether the request succeeded.
-                                                     | Mainly useful for manual and automated testing.
-========================= =============== =========  ===============================================================
+========================= ========= =======  ===============================================
+Config key                Type      Default  Description
+------------------------- --------- -------  -----------------------------------------------
+*connect_timeout*         float     N/A      | TCP connect timeout in seconds. This is
+                                             | passed along to the http_client when
+                                             | making a service call.
+*headers*                 dict      N/A      | Dict of http headers to to send with
+                                             | the outgoing request.
+*response_callbacks*      list of   []       | List of callables that are invoked after
+                          callables          | the incoming response has been validated
+                                             | and unmarshalled but before being
+                                             | returned to the calling client. This is
+                                             | useful for client decorators that would
+                                             | like to hook into the post-receive event.
+                                             | The callables are executed in the order
+                                             | they appear in the list.
+                                             | Two parameters are passed to each callable:
+                                             | - ``incoming_response`` of type
+                                             |   ``bravado_core.response.IncomingResponse``
+                                             | - ``operation`` of type
+                                             |   ``bravado_core.operation.Operation``
+*timeout*                 float     N/A      | TCP idle timeout in seconds. This is passed
+                                             | along to the http_client when making a
+                                             | service call.
+*use_msgpack*             boolean   False    | If a msgpack serialization is desired for
+                                             | the response. This will add a Accept:
+                                             | application/msgpack header to the request.
+*force_fallback_result*   boolean   False    | Whether a potentially provided fallback
+                                             | result should always be returned,
+                                             | regardless of whether the request
+                                             | succeeded.
+                                             | Mainly useful for manual and automated
+                                             | testing.
+*follow_redirects*        boolean   False    | Whether redirects returned by the server
+                                             | are followed, or returned as-is.
+                                             | **Note:** Currently, the fido HTTP client
+                                             | does not support returning redirect
+                                             | responses directly, and will always follow
+                                             | redirects.
+========================= ========= =======  ===============================================

--- a/tests/requests_client/RequestsClient/separate_params_test.py
+++ b/tests/requests_client/RequestsClient/separate_params_test.py
@@ -14,6 +14,6 @@ def test_separate_params():
         'connect_timeout': 1,
         'ssl_cert': None,
         'ssl_verify': True,
-        'allow_redirects': False,
+        'follow_redirects': False,
         'timeout': 2,
     }

--- a/tests/requests_client/RequestsFutureAdapter/header_type_casting_test.py
+++ b/tests/requests_client/RequestsFutureAdapter/header_type_casting_test.py
@@ -11,7 +11,7 @@ def test_result_header_values_are_bytes(session_mock, request_mock):
         misc_options={
             'ssl_verify': True,
             'ssl_cert': None,
-            'allow_redirects': False
+            'follow_redirects': False
         },
     ).result()
 


### PR DESCRIPTION
I'm renaming the option as it's not so much about allowing redirects, but whether we follow them automatically or not. I'm also documenting the option, and reformatting that table since currently it's too wide, and requires readers to scroll horizontally.

FYI @mattdowdell @macisamuele 