### PR TITLE
Make sure we don't go beyond pytest 4.6.X for Python 2.7 compatibility

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ httpretty
 mock
 pip>=9.0.1 # workaround to https://github.com/pypa/pip/issues/3903
 pre-commit
-pytest
+pytest<4.7  # need support for Python 2.7, see https://docs.pytest.org/en/latest/py27-py34-deprecation.html
 u-msgpack-python


### PR DESCRIPTION
This should fix the mypy failure in our build. There might be another issue when running tests with Python 2.7, but I can't reproduce that locally, I'm not sure why pip is installing too recent of a version for pyrsistent. Let's fix that separately.