### PR TITLE
Try fixing py27 builds on travis by restricting pyrsistent version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = {py27,py35,py36,py37}-{default,fido}, {py27,py35,py36,py37}-fido-reque
 
 [testenv]
 deps =
+    py27: pyrsistent<0.17
     -rrequirements-dev.txt
     fido: .[fido]
     requests2dot17: requests==2.17.0


### PR DESCRIPTION
I'll have to iterate on this PR since I can't reproduce the issue locally. I'm not sure this will work as tox probably installs the local project first - let's give it a try though.