### PR TITLE
drop python3.5 support (now EOL)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,8 +6,6 @@ environment:
   # Available python versions and their locations on https://www.appveyor.com/docs/build-environment/#python
   - PYTHON: C:\Python27-x64
     TOXENV: py27-default
-  - PYTHON: C:\Python35-x64
-    TOXENV: py35-default
   - PYTHON: C:\Python36-x64
     TOXENV: py36-default
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ matrix:
   - env: TOXENV=py27-fido-requests2dot17
     python: "2.7"
 
-  - env: TOXENV=py35-default
-    python: "3.5"
-  - env: TOXENV=py35-fido
-    python: "3.5"
-
   - env: TOXENV=py36-default
     python: "3.6"
   - env: TOXENV=py36-fido

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35,py36,py37}-{default,fido}, {py27,py35,py36,py37}-fido-requests2dot17, mypy, pre-commit
+envlist = {py27,py36,py37}-{default,fido}, {py27,py36,py37}-fido-requests2dot17, mypy, pre-commit
 
 [testenv]
 deps =


### PR DESCRIPTION
Internal ticket: CORESERV-9897 

- Fixes failing internal jenkins build
- Drops python3.5 support since it is EOL