### PR TITLE
When catching and converting exceptions, handle connection errors first

### DIFF
--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -122,10 +122,10 @@ def reraise_errors(func):
 
         try:
             return func(self, *args, **kwargs)
-        except timeout_errors as exception:
-            self.future._raise_timeout_error(exception)
         except connection_errors as exception:
             self.future._raise_connection_error(exception)
+        except timeout_errors as exception:
+            self.future._raise_timeout_error(exception)
 
     return typing.cast(F, wrapper)
 

--- a/bravado/requests_client.py
+++ b/bravado/requests_client.py
@@ -237,7 +237,7 @@ class RequestsFutureAdapter(FutureAdapter):
         return timeout
 
     def result(self, timeout=None):
-        # type: (typing.Optional[float]) -> T
+        # type: (typing.Optional[float]) -> requests.Response
         """Blocking call to wait for API response
 
         :param timeout: timeout in seconds to wait for response. Defaults to


### PR DESCRIPTION
Some HTTP libraries (in my case, aiohttp) have exception hierarchies that themselves use multiple inheritance to make sure the specific exceptions they throw also inherit from a generic timeout exception (here: asyncio.TimeoutError). Additionally, they sometimes have bugs where they don't raise the exact exception type they should be raising in specific circumstances: see [aiohttp/client.py](https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client.py#L492).

What I'm proposing here is to just switch around two catch statements: in almost all cases, connection errors are either completely separate exceptions from timeout errors, or they are the more specific exception. So catching connection errors first is the safer thing to do.

This fixes a recent build failure for bravado-asyncio, where new versions of aiohttp again changed things with connection errors. We already have [code to disable bravado connection error integration tests](https://github.com/sjaensch/bravado-asyncio/blob/master/tests/integration/bravado_integration_test.py#L42) on Windows since this was an issue on that platform for quite some time already.

I've verified that this change not only fixes the [recent build failure](https://travis-ci.org/github/sjaensch/bravado-asyncio/jobs/738684212), but also makes the tests work properly on Windows.