### PR TITLE
Fix compatibility with the uWSGI preforking mode (issue #473)

### DIFF
--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -7,10 +7,10 @@ import fido.exceptions
 import requests.structures
 import six
 import twisted.internet.error
-from twisted.web._newclient import RequestNotSent
 import typing
 from bravado_core.operation import Operation
 from bravado_core.response import IncomingResponse
+from twisted.web._newclient import RequestNotSent
 from twisted.web._newclient import RequestNotSent
 from yelp_bytes import to_bytes
 

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -7,7 +7,7 @@ import fido.exceptions
 import requests.structures
 import six
 import twisted.internet.error
-import twisted.web.client
+from twisted.web._newclient import RequestNotSent
 import typing
 from bravado_core.operation import Operation
 from bravado_core.response import IncomingResponse
@@ -104,7 +104,7 @@ class FidoFutureAdapter(FutureAdapter[T]):
         fido.exceptions.TCPConnectionError,
         twisted.internet.error.ConnectingCancelledError,
         twisted.internet.error.DNSLookupError,
-        twisted.web.client.RequestNotSent,
+        RequestNotSent,
     )
 
     def __init__(self, eventual_result):

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -11,6 +11,7 @@ from twisted.web._newclient import RequestNotSent
 import typing
 from bravado_core.operation import Operation
 from bravado_core.response import IncomingResponse
+from twisted.web._newclient import RequestNotSent
 from yelp_bytes import to_bytes
 
 from bravado._equality_util import are_objects_equal as _are_objects_equal

--- a/bravado/fido_client.py
+++ b/bravado/fido_client.py
@@ -11,7 +11,6 @@ import typing
 from bravado_core.operation import Operation
 from bravado_core.response import IncomingResponse
 from twisted.web._newclient import RequestNotSent
-from twisted.web._newclient import RequestNotSent
 from yelp_bytes import to_bytes
 
 from bravado._equality_util import are_objects_equal as _are_objects_equal


### PR DESCRIPTION
This small PR workarounds an issue with bravado's uWSGI preforking compatibility that is described https://github.com/Yelp/bravado/issues/473 .