### PR TITLE
fix build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,10 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:
     -   id: check-json
     -   id: check-yaml
+        additional_dependencies: ["ruamel.yaml==0.16.12"]
     -   id: fix-encoding-pragma
     -   id: debug-statements
     -   id: end-of-file-fixer
@@ -11,7 +12,7 @@ repos:
     -   id: trailing-whitespace
     -   id: requirements-txt-fixer
         files: requirements-dev.txt
--   repo: git://github.com/pre-commit/mirrors-autopep8
+-   repo: https://github.com/pre-commit/mirrors-autopep8
     rev: v1.4.4
     hooks:
     -   id: autopep8
@@ -21,11 +22,11 @@ repos:
     hooks:
     -   id: flake8
         exclude: ^docs
--   repo: git://github.com/asottile/reorder_python_imports
+-   repo: https://github.com/asottile/reorder_python_imports
     rev: v1.8.0
     hooks:
     -   id: reorder-python-imports
--   repo: git://github.com/Yelp/detect-secrets
+-   repo: https://github.com/Yelp/detect-secrets
     rev: v0.13.0
     hooks:
     -   id: detect-secrets

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
     Twisted<21
     -rrequirements-dev.txt
     .[fido]
-    mypy
+    mypy==0.790
 commands =
     mypy bravado tests
 


### PR DESCRIPTION
Includes the following changes:
- use https:// instead of git:// for pre-commit hook urls
- pin to a specific ruamel.yaml version when using check-yaml pre-commit hook to support python 2