### PR TITLE
Fix missing support for follow_redirects

### DIFF
--- a/bravado/client.py
+++ b/bravado/client.py
@@ -305,7 +305,7 @@ def construct_request(operation, request_options, **op_kwargs):
         request['headers']['Accept'] = 'application/msgpack'
 
     # Copy over optional request options
-    for request_option in ('connect_timeout', 'timeout'):
+    for request_option in ('connect_timeout', 'timeout', 'follow_redirects'):
         if request_option in request_options:
             request[request_option] = request_options[request_option]
 

--- a/bravado/testing/integration_test.py
+++ b/bravado/testing/integration_test.py
@@ -168,6 +168,10 @@ SWAGGER_SPEC_DICT = {
                     '301': {
                         'description': 'HTTP/301',
                     },
+                    '200': {
+                        'description': 'HTTP/200',
+                        'schema': {'$ref': '#/definitions/api_response'},
+                    },
                 },
             },
         },


### PR DESCRIPTION
This PR fixed the issue for missing support of following redirect when the client specify `follow_redirects` in the `_request_options`