### PR TITLE
fix build by pinning swagger-spec-validator<3 and fixing flake8 url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
     -   id: autopep8
         args: ['-i', '--ignore=E309,E501']
--   repo: https://gitlab.com/pycqa/flake8.git
+-   repo: https://github.com/pycqa/flake8.git
     rev: 3.7.9
     hooks:
     -   id: flake8

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = {py27,py36,py37}-{default,fido}, {py27,py36,py37}-fido-requests2dot17,
 [testenv]
 deps =
     py27: pyrsistent<0.17
+    swagger-spec-validator<3.0.0; python_version<"3.7"
     -rrequirements-dev.txt
     fido: .[fido]
     requests2dot17: requests==2.17.0
@@ -34,6 +35,8 @@ deps =
     #
     #   See also https://github.com/twisted/twisted/commit/84b79b7bdc164b17877199c27d7e3ff90a8b4e6d
     Twisted<21
+    # since we run in py 2.7 compatible mode, swagger-spec-validator>=3.0.0 causes syntax errors
+    swagger-spec-validator<3.0.0
     -rrequirements-dev.txt
     .[fido]
     mypy==0.790


### PR DESCRIPTION
swagger-spec-validator 3.0.0 drops support for python <3.7, so this pins it back to prevent syntax errors.