### PR TITLE
Fix MRO errors for TimeoutError under py311

### DIFF
--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -84,6 +84,12 @@ class FutureAdapter(typing.Generic[T]):
 
     def _raise_timeout_error(self, exception):
         # type: (BaseException) -> typing.NoReturn
+
+        # CORESERV-13799
+        # In py3.11, concurrent.future.TimeoutError is aliased to TimeoutError
+        # If a future adapter throws TimeoutError, we can directly raise BravadoTimeError
+        if isinstance(exception, TimeoutError):
+            raise BravadoTimeoutError()
         self._raise_error(BravadoTimeoutError, 'Timeout', exception)
 
     def _raise_connection_error(self, exception):

--- a/bravado/http_future.py
+++ b/bravado/http_future.py
@@ -87,7 +87,7 @@ class FutureAdapter(typing.Generic[T]):
 
         # CORESERV-13799
         # In py3.11, concurrent.future.TimeoutError is aliased to TimeoutError
-        # If a future adapter throws TimeoutError, we can directly raise BravadoTimeError
+        # If a future adapter throws TimeoutError, we can directly raise BravadoTimeoutError
         if isinstance(exception, TimeoutError):
             raise BravadoTimeoutError()
         self._raise_error(BravadoTimeoutError, 'Timeout', exception)


### PR DESCRIPTION
## Bug

In py3.11, `concurrent.futures.TimeoutError` is aliased to `TimeoutError`. This is a problem for `bravado.http_future._raise_error` which constructs a dynamic error to combine the Bravado specific error with the original error. With `TimeoutError` and `BravadoTimeoutError`, this will now throw an MRO error:
```
E       TypeError: Cannot create a consistent method resolution
E       order (MRO) for bases TimeoutError, BravadoTimeoutError
```
This issue occurs with bravado-asyncio which explicitly throws `concurrent.futures.TimeoutError`.

## Solution

`_raise_error` was created for python2 to ensure the original exception was not lost. With python 3, we can directly throw `BravadoTimeoutError` without losing the original exception.

Checking for the specific case where the caught exception is `TimeoutError`, we will raise `BravadoTimeoutError`

TODO: Drop py2. This test will fail under py2 because `TimeoutError` doesn't exist until py33.

## Validation

bravady-asyncio has tests that will fail under py311: `tests/integration/bravado_integration_test.py::TestServerBravadoAsyncioClient`. This PR will make those tests pass.

TODO: Write similar tests in this repo.