### PR TITLE
drop old pythons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,22 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - py38
-          - py310
-          - py311
+          - env: py38
+            version: '3.8'
+          - env: py310
+            version: '3.10'
+          - env: py311
+            version: '3.11'
         httplib:
           - default
           - fido
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: ${{ matrix.python.version }}
       - run: pip install tox
-      - run: tox -e ${{ matrix.python }}-${{ matrix.httplib }}
+      - run: tox -e ${{ matrix.python.env }}-${{ matrix.httplib }}
 
   misc:
     runs-on: ubuntu-22.04
@@ -34,6 +37,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: '3.8'
       - run: pip install tox
       - run: tox -e ${{ matrix.tox }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,28 +3,27 @@ name: build
 on: push
 jobs:
   tox:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         python:
-          - py27
-          - py36
-          - py37
+          - py38
+          - py310
+          - py311
         httplib:
           - default
           - fido
-          - fido-requests2dot17
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.10
       - run: pip install tox
       - run: tox -e ${{ matrix.python }}-${{ matrix.httplib }}
 
   misc:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -35,6 +34,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.10
       - run: pip install tox
       - run: tox -e ${{ matrix.tox }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     -   id: autopep8
         args: ['-i', '--ignore=E309,E501']
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 3.7.9
+    rev: 5.0.4
     hooks:
     -   id: flake8
         exclude: ^docs

--- a/bravado/exception.py
+++ b/bravado/exception.py
@@ -4,22 +4,6 @@ import typing
 from bravado_core.response import IncomingResponse
 from six import with_metaclass
 
-try:
-    # ignored type ConnectionError is introduced in python3.3+ (mypy runs as 2.7)
-    from builtins import ConnectionError as base_connection_error  # type: ignore
-except ImportError:
-    # ConnectionError was introduced in python 3.3+
-    base_connection_error = OSError
-
-
-try:
-    # ignored type TimeoutError is introduced in python3.3+ (mypy runs as 2.7)
-    from builtins import TimeoutError as base_timeout_error  # type: ignore
-except ImportError:
-    # TimeoutError was introduced in python 3.3+
-    base_timeout_error = OSError
-
-
 if getattr(typing, 'TYPE_CHECKING', False):
     T = typing.TypeVar('T')
 
@@ -378,11 +362,11 @@ class HTTPNetworkAuthenticationRequired(HTTPServerError):
     status_code = 511
 
 
-class BravadoTimeoutError(base_timeout_error):
+class BravadoTimeoutError(TimeoutError):
     pass
 
 
-class BravadoConnectionError(base_connection_error):
+class BravadoConnectionError(ConnectionError):
     pass
 
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 ignore_missing_imports = True
-python_version = 2.7
+python_version = 3.8
 strict_optional = True
 warn_redundant_casts = True
 disallow_untyped_calls = False

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,5 @@ mock
 mypy==0.790
 pip>=9.0.1 # workaround to https://github.com/pypa/pip/issues/3903
 pre-commit
-pytest<4.7  # need support for Python 2.7, see https://docs.pytest.org/en/latest/py27-py34-deprecation.html
+pytest==7.4.4
 u-msgpack-python

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ bottle
 ephemeral_port_reserve
 httpretty
 mock
+mypy==0.790
 pip>=9.0.1 # workaround to https://github.com/pypa/pip/issues/3903
 pre-commit
 pytest<4.7  # need support for Python 2.7, see https://docs.pytest.org/en/latest/py27-py34-deprecation.html

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@ bottle
 ephemeral_port_reserve
 httpretty
 mock
-mypy==0.790
 pip>=9.0.1 # workaround to https://github.com/pypa/pip/issues/3903
 pre-commit
 pytest==7.4.4

--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,5 @@ setup(
             'pytest',
         ],
     },
-    python_requires='!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5.0',
+    python_requires='>=3.8',
 )

--- a/tests/testing/response_mocks_test.py
+++ b/tests/testing/response_mocks_test.py
@@ -32,10 +32,10 @@ def mock_metadata():
 
 def test_response_mock_signatures():
     """Make sure the mocks' __call__ methods have the same signature as HttpFuture.response"""
-    response_signature = inspect.getargspec(HttpFuture.response)
+    response_signature = inspect.getfullargspec(HttpFuture.response)
 
-    assert inspect.getargspec(BravadoResponseMock.__call__) == response_signature
-    assert inspect.getargspec(FallbackResultBravadoResponseMock.__call__) == response_signature
+    assert inspect.getfullargspec(BravadoResponseMock.__call__) == response_signature
+    assert inspect.getfullargspec(FallbackResultBravadoResponseMock.__call__) == response_signature
 
 
 def test_bravado_response(mock_result):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py38,py310}-{default,fido}, mypy, pre-commit
+envlist = {py38,py310,py311}-{default,fido}, mypy, pre-commit
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-{default,fido}, py38-fido-requests2dot17, mypy, pre-commit
+envlist = py38-{default,fido}, mypy, pre-commit
 
 [testenv]
 deps =
@@ -7,7 +7,6 @@ deps =
     swagger-spec-validator<3.0.0; python_version<"3.7"
     -rrequirements-dev.txt
     fido: .[fido]
-    requests2dot17: requests==2.17.0
 setenv =
     default: PYTEST_ADDOPTS=--ignore=tests/fido_client --ignore=tests/integration/fido_client_test.py
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-{default,fido}, mypy, pre-commit
+envlist = {py38,py310}-{default,fido}, mypy, pre-commit
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,6 @@ envlist = {py38,py310}-{default,fido}, mypy, pre-commit
 
 [testenv]
 deps =
-    py27: pyrsistent<0.17
-    swagger-spec-validator<3.0.0; python_version<"3.7"
     -rrequirements-dev.txt
     fido: .[fido]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,9 @@ commands =
 
 [testenv:mypy]
 basepython = python3.8
+deps =
+    -rrequirements-dev.txt
+    mypy==0.790
 commands =
     mypy bravado tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,21 +25,6 @@ commands =
 
 [testenv:mypy]
 basepython = python3.8
-deps =
-    # TODO: Latest twisted (>=21) and mypy (0.8XX) don't get along. Remove when they're friends again.
-    #
-    #   LOG:  Bailing due to parse errors
-    #   LOG:  Build finished in 0.355 seconds with 40 modules, and 1 errors
-    #   .tox/mypy/lib/python3.7/site-packages/twisted/internet/error.py:18: error: invalid syntax
-    #   Found 1 error in 1 file (errors prevented further checking)
-    #
-    #   See also https://github.com/twisted/twisted/commit/84b79b7bdc164b17877199c27d7e3ff90a8b4e6d
-    Twisted<21
-    # since we run in py 2.7 compatible mode, swagger-spec-validator>=3.0.0 causes syntax errors
-    swagger-spec-validator<3.0.0
-    -rrequirements-dev.txt
-    .[fido]
-    mypy==0.790
 commands =
     mypy bravado tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py36,py37}-{default,fido}, {py27,py36,py37}-fido-requests2dot17, mypy, pre-commit
+envlist = py38-{default,fido}, py38-fido-requests2dot17, mypy, pre-commit
 
 [testenv]
 deps =
@@ -15,7 +15,7 @@ commands =
 
 [testenv:pre-commit]
 skip_install = True
-basepython = python3.7
+basepython = python3.8
 deps = pre-commit>=0.12.0
 setenv =
     LC_CTYPE=en_US.UTF-8
@@ -24,7 +24,7 @@ commands =
     pre-commit {posargs:run --all-files}
 
 [testenv:mypy]
-basepython = python3.7
+basepython = python3.8
 deps =
     # TODO: Latest twisted (>=21) and mypy (0.8XX) don't get along. Remove when they're friends again.
     #

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ commands =
 basepython = python3.8
 deps =
     -rrequirements-dev.txt
+    .[fido]
     mypy==0.790
 commands =
     mypy bravado tests


### PR DESCRIPTION
All of our builds were in EOL pythons. This raises the minimum version to 3.8 and adds builds for 3.10 and 3.11 as well.

Some additional changes here:
- Bump CI base ubuntu to something also not-EOL
- mypy error due to compatibility logic in `bravado/exception.py` was simplest to fix by just dropping the python 2 logic
- pytest needed an upgrade to support python 3.10+
- `inspect.getargspec` was removed in python 3.11, so I had to fix a test

This repo could use a lot of TLC, but I want to unblock https://github.com/Yelp/bravado/pull/499